### PR TITLE
ci: add missing system deps to release workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --all-extras
 
+      - name: Install system dependencies for plugin imports
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends libgl1 libglib2.0-0
+          rm -rf /var/lib/apt/lists/*
+
       - name: Run full test suite
         run: |
           uv run pytest tests/ \


### PR DESCRIPTION
## Summary
- Added `libgl1` and `libglib2.0-0` system package installation to the pre-release validation step in `pypi-release.yml`
- These packages are needed by OpenCV (used by adaclip plugin) and were already present in `ci.yml` and `plugin-runtime-smoke.yml`
- Fixes the v0.4.0 release failure: `libGL.so.1: cannot open shared object file`

## Test plan
- [ ] CI passes on this PR
- [ ] Re-tag v0.4.0 after merge to trigger release