### PR TITLE
docs(plugins): register cuvis-ai-trackeval plugin

### DIFF
--- a/configs/plugins/registry.yaml
+++ b/configs/plugins/registry.yaml
@@ -20,6 +20,15 @@ plugins:
     provides:
       - cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector
 
+  trackeval:
+    # TrackEval-based tracking metric nodes for HOTA, CLEAR, and Identity evaluation
+    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
+    tag: "v0.1.0"
+    provides:
+      - cuvis_ai_trackeval.node.HOTAMetricNode
+      - cuvis_ai_trackeval.node.CLEARMetricNode
+      - cuvis_ai_trackeval.node.IdentityMetricNode
+
   sam3:
     # SAM3-based video object tracking plugin
     path: "../../cuvis-ai-sam3"

--- a/configs/plugins/trackeval.yaml
+++ b/configs/plugins/trackeval.yaml
@@ -1,0 +1,17 @@
+# TrackEval Plugin Manifest (selective load convenience)
+#
+# Canonical source of truth for plugin entries remains:
+#   configs/plugins/registry.yaml
+#
+# Use this file when you want to load only TrackEval metric nodes:
+#   uv run restore-pipeline --plugins-path configs/plugins/trackeval.yaml
+
+plugins:
+  trackeval:
+    # TrackEval-based tracking metric nodes for HOTA, CLEAR, and Identity evaluation
+    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
+    tag: "v0.1.0"
+    provides:
+      - cuvis_ai_trackeval.node.HOTAMetricNode
+      - cuvis_ai_trackeval.node.CLEARMetricNode
+      - cuvis_ai_trackeval.node.IdentityMetricNode

--- a/docs/plugin-system/index.md
+++ b/docs/plugin-system/index.md
@@ -134,6 +134,7 @@ detector = AdaCLIPDetector(prompt="plastic wrapper", threshold=0.5)
 ### Official Plugins
 
 - **[cuvis-ai-adaclip](https://github.com/cubert-hyperspectral/cuvis-ai-adaclip)** - AdaCLIP vision-language anomaly detection using CLIP embeddings
+- **[cuvis-ai-trackeval](https://github.com/cubert-hyperspectral/cuvis-ai-trackeval)** - External TrackEval metric nodes for HOTA, CLEAR, and Identity tracking evaluation
 
 ### Central Plugin Registry
 
@@ -149,6 +150,7 @@ uv run restore-pipeline \
 
 **Registered Plugins:**
 - **[cuvis-ai-adaclip](https://github.com/cubert-hyperspectral/cuvis-ai-adaclip)** - AdaCLIP vision-language anomaly detection with Fisher band selection and mRMR algorithms
+- **[cuvis-ai-trackeval](https://github.com/cubert-hyperspectral/cuvis-ai-trackeval)** - TrackEval metric nodes for evaluating COCO tracking predictions against ground truth
 
 **Want to add your plugin?** See [Contributing Guide](../development/contributing.md#plugin-contribution-workflow) for submission instructions.
 

--- a/docs/plugin-system/usage.md
+++ b/docs/plugin-system/usage.md
@@ -44,6 +44,7 @@ outputs = detector(data=your_hyperspectral_data)
 cuvis-ai maintains official plugins:
 
 - **[cuvis-ai-adaclip](https://github.com/cubert-hyperspectral/cuvis-ai-adaclip)** - AdaCLIP vision-language anomaly detection
+- **[cuvis-ai-trackeval](https://github.com/cubert-hyperspectral/cuvis-ai-trackeval)** - TrackEval metric nodes for HOTA, CLEAR, and Identity tracking evaluation
 
 ### Community Plugins
 
@@ -114,6 +115,14 @@ plugins:
     provides:
       - cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector
 
+  trackeval:
+    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
+    tag: "v0.1.0"
+    provides:
+      - cuvis_ai_trackeval.node.HOTAMetricNode
+      - cuvis_ai_trackeval.node.CLEARMetricNode
+      - cuvis_ai_trackeval.node.IdentityMetricNode
+
   # Add your custom local plugin
   my_dev_plugin:
     path: "../my-plugin"
@@ -135,6 +144,7 @@ registry.load_plugins("my_plugins.yaml")
 
 # Now you have access to:
 # - Registry plugins (adaclip)
+# - Official tracking metrics (trackeval)
 # - Local development plugins (my_dev_plugin)
 # - Private plugins (private_plugin)
 ```
@@ -155,6 +165,14 @@ For reproducible workflows, create a `plugins.yaml` manifest:
 
 ```yaml
 plugins:
+  trackeval:
+    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
+    tag: "v0.1.0"
+    provides:
+      - cuvis_ai_trackeval.node.HOTAMetricNode
+      - cuvis_ai_trackeval.node.CLEARMetricNode
+      - cuvis_ai_trackeval.node.IdentityMetricNode
+
   adaclip:
     repo: "https://github.com/cubert-hyperspectral/cuvis-ai-adaclip.git"
     tag: "v0.1.1"
@@ -213,6 +231,11 @@ registry.load_plugin(
 - Automatic caching in `~/.cuvis_plugins/`
 - Tag verification on subsequent loads
 - Dependency installation from `pyproject.toml`
+
+For a ready-to-use selective manifest for tracking metric nodes, load
+`configs/plugins/trackeval.yaml` to pull the released
+[`cuvis-ai-trackeval`](https://github.com/cubert-hyperspectral/cuvis-ai-trackeval)
+plugin at `v0.1.0`.
 
 ### From Local Path
 

--- a/tests/plugins/test_plugin_manifest_sync.py
+++ b/tests/plugins/test_plugin_manifest_sync.py
@@ -10,30 +10,37 @@ from cuvis_ai_core.utils.plugin_config import PluginManifest
 pytestmark = pytest.mark.unit
 
 REGISTRY_PATH = Path("configs/plugins/registry.yaml")
-ADACLIP_MANIFEST_PATH = Path("configs/plugins/adaclip.yaml")
-PLUGIN_NAME = "adaclip"
+PLUGIN_MANIFESTS = {
+    "adaclip": Path("configs/plugins/adaclip.yaml"),
+    "trackeval": Path("configs/plugins/trackeval.yaml"),
+}
 
 
-def test_adaclip_manifest_exists() -> None:
-    assert ADACLIP_MANIFEST_PATH.exists(), f"Missing AdaCLIP manifest: {ADACLIP_MANIFEST_PATH}"
+@pytest.mark.parametrize(("plugin_name", "manifest_path"), PLUGIN_MANIFESTS.items())
+def test_selective_manifest_exists(plugin_name: str, manifest_path: Path) -> None:
+    assert manifest_path.exists(), f"Missing {plugin_name} manifest: {manifest_path}"
 
 
-def test_adaclip_manifest_contains_only_adaclip_plugin() -> None:
-    manifest = PluginManifest.from_yaml(ADACLIP_MANIFEST_PATH)
-    assert set(manifest.plugins.keys()) == {PLUGIN_NAME}
+@pytest.mark.parametrize(("plugin_name", "manifest_path"), PLUGIN_MANIFESTS.items())
+def test_selective_manifest_contains_only_target_plugin(
+    plugin_name: str, manifest_path: Path
+) -> None:
+    manifest = PluginManifest.from_yaml(manifest_path)
+    assert set(manifest.plugins.keys()) == {plugin_name}
 
 
-def test_adaclip_manifest_matches_registry_entry() -> None:
+@pytest.mark.parametrize(("plugin_name", "manifest_path"), PLUGIN_MANIFESTS.items())
+def test_selective_manifest_matches_registry_entry(plugin_name: str, manifest_path: Path) -> None:
     registry_manifest = PluginManifest.from_yaml(REGISTRY_PATH)
-    adaclip_manifest = PluginManifest.from_yaml(ADACLIP_MANIFEST_PATH)
+    selective_manifest = PluginManifest.from_yaml(manifest_path)
 
-    assert PLUGIN_NAME in registry_manifest.plugins, (
-        f"Plugin '{PLUGIN_NAME}' must exist in registry: {REGISTRY_PATH}"
+    assert plugin_name in registry_manifest.plugins, (
+        f"Plugin '{plugin_name}' must exist in registry: {REGISTRY_PATH}"
     )
-    assert PLUGIN_NAME in adaclip_manifest.plugins, (
-        f"Plugin '{PLUGIN_NAME}' must exist in selective manifest: {ADACLIP_MANIFEST_PATH}"
+    assert plugin_name in selective_manifest.plugins, (
+        f"Plugin '{plugin_name}' must exist in selective manifest: {manifest_path}"
     )
 
-    assert adaclip_manifest.plugins[PLUGIN_NAME].model_dump() == (
-        registry_manifest.plugins[PLUGIN_NAME].model_dump()
+    assert selective_manifest.plugins[plugin_name].model_dump() == (
+        registry_manifest.plugins[plugin_name].model_dump()
     )


### PR DESCRIPTION
## Summary
- register `cuvis-ai-trackeval` as an official external plugin in the central plugin registry
- add a selective `configs/plugins/trackeval.yaml` manifest pinned to `v0.1.0`
- document the TrackEval plugin in the plugin-system discovery pages and extend manifest-sync coverage

## Validation
- `uv run pytest tests/plugins/test_plugin_manifest_sync.py tests/plugins/test_plugin_contracts.py -v`
