### PR TITLE
ci(release): run gh-pages docs deploy inside cuvis SDK container

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -232,12 +232,17 @@ jobs:
     name: Deploy Documentation to gh-pages
     needs: create-github-release
     runs-on: ubuntu-latest
+    container:
+      image: cubertgmbh/cuvis_pyil:3.5.0-ubuntu24.04
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for mike
+
+      - name: Mark workspace as safe for Git versioning
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -249,6 +254,12 @@ jobs:
 
       - name: Install documentation dependencies
         run: uv sync --locked --extra docs
+
+      - name: Install system dependencies for OpenCV / ffmpeg imports
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends libgl1 libglib2.0-0 ffmpeg
+          rm -rf /var/lib/apt/lists/*
 
       - name: Configure git for deployment
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2 - 2026-05-11
+
+- **CI:** run the gh-pages `deploy-docs` job inside `cubertgmbh/cuvis_pyil:3.5.0-ubuntu24.04` with `libgl1` / `libglib2.0-0` / `ffmpeg` installed, matching the working `doc-build` job in `ci.yml`. The 0.7.1 deploy failed because the auto-generated Nodes-catalog generator imports `cuvis_ai.node`, which transitively initializes the `cuvis` package and aborts on a vanilla runner. No `cuvis_ai` code changes — this release exists solely to re-trigger the release pipeline so gh-pages actually updates.
+
 ## 0.7.1 - 2026-05-11
 
 - **Docs IA restructure** (ALL-5655). Nine top-level sections — Home, Get Started, Concepts, Tutorials, Catalogs, Workflows, Agentic Integration, Deployment, Reference — ordered as a learning path. Major moves: `user-guide/{installation,quickstart}` → `get-started/`; `how-to/*` → `workflows/`; `node-catalog/*` → `catalogs/nodes/*`; `config/*` → `reference/configuration/`; `api/*` → `reference/python-api/`; `plugin-system/*` → `reference/plugin-development/`; `development/*` → `reference/contributing/`; `grpc/*` + `use_cases/grpc-workflow.md` → `deployment/`. New: agentic-integration section, datasets catalog mirrored from HuggingFace, notebook tutorial gallery, `get-started/first-pipeline.md`, `workflows/{statistical,gradient}-training.md`. Removed `docs/use_cases/`, `user-guide/configuration.md` stub, duplicate `plugin-system/overview.md`. **All URLs change — no redirects.** `mkdocs build --strict` clean.


### PR DESCRIPTION
## Summary
- The `Deploy Documentation to gh-pages` job in `pypi-release.yml` runs on a vanilla `ubuntu-latest`. Since 0.7.1 the docs build invokes the auto-generated Nodes catalog generator (`scripts/generate_node_catalog.py`), which imports `cuvis_ai.node`, which transitively initializes the `cuvis` package — and `cuvis` aborts with `CUVIS environmental variable is not set!` without the SDK.
- This made the v0.7.1 release pipeline fail at the final step (PyPI publish and GitHub Release both succeeded; only gh-pages didn't update).
- Fix: run `deploy-docs` inside `cubertgmbh/cuvis_pyil:3.5.0-ubuntu24.04` and apt-install `libgl1 libglib2.0-0 ffmpeg`, mirroring the working `doc-build` job in `ci.yml`.

## Test plan
- [ ] CI green on this PR.
- [ ] After merge, re-trigger `pypi-release.yml` for `v0.7.1` (or wait for the next tag) and confirm gh-pages updates.