### PR TITLE
feat(plugins): add augment plugin manifest (v0.1.1)

### DIFF
--- a/configs/plugins/augment.yaml
+++ b/configs/plugins/augment.yaml
@@ -1,0 +1,14 @@
+# Augment plugin manifest (data augmentation for HSI training pipelines)
+#
+# Canonical registry: configs/plugins/registry.yaml
+#
+#   uv run restore-pipeline --plugins-path configs/plugins/augment.yaml
+
+plugins:
+  augment:
+    # Local development override (optional):
+    # path: "../../../cuvis-ai-augment"
+    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
+    tag: "v0.1.0"
+    provides:
+      - cuvis_ai_augment.node.compose.AugmentationCompose

--- a/configs/plugins/augment.yaml
+++ b/configs/plugins/augment.yaml
@@ -9,6 +9,6 @@ plugins:
     # Local development override (optional):
     # path: "../../../cuvis-ai-augment"
     repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
-    tag: "v0.1.0"
+    tag: "v0.1.1"
     provides:
       - cuvis_ai_augment.node.compose.AugmentationCompose


### PR DESCRIPTION
## Summary

- Adds `configs/plugins/augment.yaml` registering the `cuvis-ai-augment` plugin at tag `v0.1.1`
- Plugin provides `AugmentationCompose` — a single Node that applies stochastic spatial augmentations (HFlip, VFlip, Rot90, SpatialCrop) to `(B, H, W, C)` hyperspectral cubes and paired masks, exclusively during `ExecutionStage.TRAIN`

## Manifest

```yaml
plugins:
  augment:
    repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
    tag: "v0.1.1"
    provides:
      - cuvis_ai_augment.node.compose.AugmentationCompose
```

## Verification

Verified live via `NodeRegistry.load_plugins()` with `tag: v0.1.1`:

```
Loaded plugins: ['augment']
```

Plugin installs cleanly from the tagged release, all dependencies resolve, and `AugmentationCompose` imports without error.

## Links

- Plugin repo: https://github.com/cubert-hyperspectral/cuvis-ai-augment
- Release v0.1.1: https://github.com/cubert-hyperspectral/cuvis-ai-augment/releases/tag/v0.1.1
- Tutorial notebook: `notebooks/use_cases/lentils_augmentation.ipynb`