### PR TITLE
docs: add GoatCounter page-view analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added GoatCounter page-view analytics to the docs site via Material's custom-analytics partial (`overrides/partials/integrations/analytics/custom.html`, `extra.analytics.provider: custom`). No cookies, no consent banner; tracked at `https://cuvis-ai.goatcounter.com`.
+
 ## 0.7.2 - 2026-05-11
 
 - **CI:** run the gh-pages `deploy-docs` job inside `cubertgmbh/cuvis_pyil:3.5.0-ubuntu24.04` with `libgl1` / `libglib2.0-0` / `ffmpeg` installed, matching the working `doc-build` job in `ci.yml`. The 0.7.1 deploy failed because the auto-generated Nodes-catalog generator imports `cuvis_ai.node`, which transitively initializes the `cuvis` package and aborts on a vanilla runner. No `cuvis_ai` code changes — this release exists solely to re-trigger the release pipeline so gh-pages actually updates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 # MkDocs Configuration for cuvis-ai
-site_name: Cuvis.AI
-site_description: PyTorch Lightning Training Pipeline for Hyperspectral Data Analysis
+site_name: Cuvis.AI Documentation
+site_description: Cuvis.AI is an open-source framework for building modular, extensible AI pipelines for real-time hyperspectral video processing, analysis, and deployment.
 site_author: Cubert GmbH
-site_url: https://docs.cuvis.ai/
+site_url: https://cubert-hyperspectral.github.io/cuvis-ai/
 
 # Repository
 repo_name: cubert-hyperspectral/cuvis-ai

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ copyright: Copyright &copy; 2025-2026 Cubert GmbH
 # Configuration
 theme:
   name: material
+  custom_dir: overrides
   language: en
   features:
     - navigation.instant
@@ -249,6 +250,8 @@ extra:
       link: https://www.cubert-hyperspectral.com/
   version:
     provider: mike
+  analytics:
+    provider: custom
 
 # CSS
 extra_css:

--- a/overrides/partials/integrations/analytics/custom.html
+++ b/overrides/partials/integrations/analytics/custom.html
@@ -1,0 +1,4 @@
+<script
+  data-goatcounter="https://cuvis-ai.goatcounter.com/count"
+  async
+  src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
## Summary

- Wires GoatCounter (`https://cuvis-ai.goatcounter.com`) into the Material for MkDocs site via the documented custom-analytics slot.
- Three-line change in `mkdocs.yml` (`theme.custom_dir: overrides` + `extra.analytics.provider: custom`) plus the actual `<script>` tag in `overrides/partials/integrations/analytics/custom.html`.
- Cookieless, async, no consent banner needed. CHANGELOG entry added under `## Unreleased`.
- Will ship to gh-pages automatically on the next PyPI release via the existing `mike deploy` job in `pypi-release.yml` — no workflow edits.

## Test plan

- [x] `uv run mkdocs build` succeeds (13.6 s, no analytics-related warnings).
- [x] Generated HTML contains `<script data-goatcounter="...">` in `<head>` on `index.html`, `user-guide/installation/`, `api/nodes/`, `concepts/overview/`.
- [x] Pre-push hook: full pytest (872 passed, 2 skipped), ruff, interrogate (96.0%) all green.
- [ ] After merge + first deploy: confirm pageviews land in the GoatCounter dashboard; filter localhost noise if needed.