### PR TITLE
fix(metrics): bound BinaryAveragePrecision state across epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed `AnomalyDetectionMetrics` average precision: switched to histogram-based `BinaryAveragePrecision(thresholds=N)` so state is bounded by construction, and reset only on `(stage, epoch)` boundaries so the metric accumulates across batches via `update()` within a validation epoch — the per-batch emitted value is a running AP that converges to true epoch-level AP, instead of a leak-prone cumulative or a noisy per-batch AP.
+
 ## 0.7.3 - 2026-05-18
 
 - Added GoatCounter page-view analytics to the docs site via Material's custom-analytics partial (`overrides/partials/integrations/analytics/custom.html`, `extra.analytics.provider: custom`). No cookies, no consent banner; tracked at `https://cuvis-ai.goatcounter.com`.
@@ -113,7 +117,6 @@
 - Fixed SAM3 batch-runner control flow and mask-overlay color handling.
 - Fixed JSON reader robustness and pre-push regressions in manifest sync, CLI commands, and statistical-contract tests.
 - Fixed video/tracking fallback and output handling: `VideoIterator` now falls back to OpenCV when torchcodec is unavailable, `output_video_path` naming is normalized, and ByteTrack JSON output path heuristics were hardened.
-- Fixed `AnomalyDetectionMetrics` average precision: switched to histogram-based `BinaryAveragePrecision(thresholds=N)` so state is bounded by construction, and reset only on `(stage, epoch)` boundaries so the metric accumulates across batches via `update()` within a validation epoch — the per-batch emitted value is a running AP that converges to true epoch-level AP, instead of a leak-prone cumulative or a noisy per-batch AP.
 
 ## 0.4.0 - 2026-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - Fixed SAM3 batch-runner control flow and mask-overlay color handling.
 - Fixed JSON reader robustness and pre-push regressions in manifest sync, CLI commands, and statistical-contract tests.
 - Fixed video/tracking fallback and output handling: `VideoIterator` now falls back to OpenCV when torchcodec is unavailable, `output_video_path` naming is normalized, and ByteTrack JSON output path heuristics were hardened.
+- Fixed `AnomalyDetectionMetrics` average precision: switched to histogram-based `BinaryAveragePrecision(thresholds=N)` so state is bounded by construction, and reset only on `(stage, epoch)` boundaries so the metric accumulates across batches via `update()` within a validation epoch — the per-batch emitted value is a running AP that converges to true epoch-level AP, instead of a leak-prone cumulative or a noisy per-batch AP.
 
 ## 0.4.0 - 2026-02-27
 

--- a/cuvis_ai/node/metrics.py
+++ b/cuvis_ai/node/metrics.py
@@ -142,24 +142,33 @@ class AnomalyDetectionMetrics(Node):
     def __init__(
         self,
         execution_stages: set[ExecutionStage] | None = None,
+        ap_thresholds: int = 200,
         **kwargs,
     ) -> None:
+        self.ap_thresholds = ap_thresholds
         name, execution_stages = Node.consume_base_kwargs(
             kwargs, execution_stages or {ExecutionStage.VAL, ExecutionStage.TEST}
         )
         super().__init__(
             name=name,
             execution_stages=execution_stages,
+            ap_thresholds=ap_thresholds,
             **kwargs,
         )
 
-        # Initialize torchmetrics for binary classification
-        # These are stateless (compute per-batch) since we don't call update()
+        # Precision/Recall/F1/IoU keep O(1) running confmat state and are stateless
+        # under torchmetrics __call__ (full_state_update=False) — per-batch values.
+        # BinaryAveragePrecision uses histogram-based AP (thresholds=N) so state is
+        # O(N) instead of O(n_pixels). We accumulate via update() across batches
+        # within a (stage, epoch) and reset only at the boundary, so the value
+        # emitted each batch is a *running* AP across batches seen so far in the
+        # current epoch — the last batch's value is true epoch-level AP.
         self.precision_metric = BinaryPrecision()
         self.recall_metric = BinaryRecall()
         self.f1_metric = BinaryF1Score()
         self.iou_metric = BinaryJaccardIndex()
-        self.average_precision_metric = BinaryAveragePrecision()
+        self.average_precision_metric = BinaryAveragePrecision(thresholds=ap_thresholds)
+        self._ap_last_key: tuple[ExecutionStage, int] | None = None
 
     def forward(
         self,
@@ -232,7 +241,14 @@ class AnomalyDetectionMetrics(Node):
         if logits is not None:
             raw_scores = logits.squeeze(-1).flatten().float()
             probs_for_ap = torch.sigmoid(raw_scores)
-            average_precision = self.average_precision_metric(probs_for_ap, targets_flat)
+
+            current_key = (context.stage, context.epoch)
+            if self._ap_last_key != current_key:
+                self.average_precision_metric.reset()
+                self._ap_last_key = current_key
+
+            self.average_precision_metric.update(probs_for_ap, targets_flat)
+            average_precision = self.average_precision_metric.compute()
 
             metrics.append(
                 Metric(

--- a/tests/training/test_metrics.py
+++ b/tests/training/test_metrics.py
@@ -1,5 +1,7 @@
 """Tests for metric leaf nodes."""
 
+import math
+
 import pytest
 import torch
 from cuvis_ai_schemas.enums import ExecutionStage
@@ -196,6 +198,134 @@ class TestAnomalyDetectionMetrics:
         metrics = {m.name: m.value for m in outputs["metrics"]}
 
         assert "precision" in metrics
+
+    def test_average_precision_state_does_not_accumulate_batches(self):
+        """BinaryAveragePrecision must keep bounded state across batches."""
+        metric_node = AnomalyDetectionMetrics()
+        b, h, w = 1, 32, 32
+        decisions = torch.randint(0, 2, (b, h, w, 1)).bool()
+        targets = torch.randint(0, 2, (b, h, w, 1)).bool()
+        logits = torch.randn(b, h, w, 1)
+        for batch_idx in range(80):
+            ctx = Context(
+                stage=ExecutionStage.VAL,
+                epoch=batch_idx // 20,
+                batch_idx=batch_idx,
+                global_step=batch_idx,
+            )
+            metric_node.forward(decisions, targets, ctx, logits=logits)
+
+        ap = metric_node.average_precision_metric
+        # Histogram-mode AP must not store raw preds/targets per batch.
+        assert len(getattr(ap, "preds", [])) == 0
+        assert len(getattr(ap, "target", [])) == 0
+        # Histogram confmat is the bounded state: shape (thresholds, 2, 2).
+        confmat = getattr(ap, "confmat", None)
+        assert confmat is not None, "thresholds=N mode should expose a confmat buffer"
+        assert confmat.numel() == metric_node.ap_thresholds * 4
+
+    @staticmethod
+    def _mixed_targets(b: int, h: int, w: int) -> torch.Tensor:
+        """Half-positive / half-negative target mask so AP is non-degenerate."""
+        targets = torch.zeros(b, h, w, 1, dtype=torch.bool)
+        targets[..., : w // 2, :] = True
+        return targets
+
+    def test_ap_resets_on_epoch_boundary(self):
+        """AP state must reset between epochs (no cross-epoch contamination)."""
+        metric_node = AnomalyDetectionMetrics()
+        b, h, w = 1, 8, 8
+        targets = self._mixed_targets(b, h, w)
+        decisions = torch.zeros(b, h, w, 1).bool()
+
+        # Aligned logits: high where target=True, low where target=False → AP ≈ 1.
+        aligned = torch.where(targets, torch.tensor(10.0), torch.tensor(-10.0))
+        ctx0 = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=0)
+        outputs0 = metric_node.forward(decisions, targets, ctx0, logits=aligned)
+        ap0 = next(m.value for m in outputs0["metrics"] if m.name == "average_precision")
+        assert ap0 > 0.99
+
+        # Inverted logits: high where target=False → AP collapses well below 1.
+        # If state leaked across epoch boundary, ap1 would be pulled toward ap0.
+        inverted = -aligned
+        ctx1 = Context(stage=ExecutionStage.VAL, epoch=1, batch_idx=0)
+        outputs1 = metric_node.forward(decisions, targets, ctx1, logits=inverted)
+        ap1 = next(m.value for m in outputs1["metrics"] if m.name == "average_precision")
+        assert ap1 < 0.6, f"epoch-1 AP should reflect inverted-only data, got {ap1}"
+
+    def test_ap_accumulates_within_epoch(self):
+        """Within an epoch, AP accumulates across batches via update()."""
+        torch.manual_seed(0)
+        metric_node = AnomalyDetectionMetrics()
+        b, h, w = 1, 16, 16
+        targets = self._mixed_targets(b, h, w)
+        decisions = torch.zeros(b, h, w, 1).bool()
+
+        aligned = torch.where(targets, torch.tensor(10.0), torch.tensor(-10.0))
+        inverted = -aligned
+
+        # Batch 0: aligned logits → running AP ≈ 1.
+        ctx0 = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=0)
+        out0 = metric_node.forward(decisions, targets, ctx0, logits=aligned)
+        ap0 = next(m.value for m in out0["metrics"] if m.name == "average_precision")
+
+        # Batch 1: inverted logits → running AP across batches 0+1 drops below ap0.
+        ctx1 = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=1)
+        out1 = metric_node.forward(decisions, targets, ctx1, logits=inverted)
+        ap1 = next(m.value for m in out1["metrics"] if m.name == "average_precision")
+
+        # Batch 2: more inverted data → running AP drops further toward inverted-only.
+        ctx2 = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=2)
+        out2 = metric_node.forward(decisions, targets, ctx2, logits=inverted)
+        ap2 = next(m.value for m in out2["metrics"] if m.name == "average_precision")
+
+        assert ap0 > 0.99, "first batch with aligned logits should give AP ≈ 1"
+        assert ap1 < ap0, "running AP should drop after an inverted batch"
+        assert ap2 < ap1, "running AP should drop further after a second inverted batch"
+
+    def test_ap_stage_boundary_val_to_test(self):
+        """VAL state must not leak into TEST even when epoch number matches."""
+        metric_node = AnomalyDetectionMetrics()
+        b, h, w = 1, 8, 8
+        targets = self._mixed_targets(b, h, w)
+        decisions = torch.zeros(b, h, w, 1).bool()
+        aligned = torch.where(targets, torch.tensor(10.0), torch.tensor(-10.0))
+        inverted = -aligned
+
+        # VAL epoch 5: inverted logits accumulate (low AP).
+        ctx_val = Context(stage=ExecutionStage.VAL, epoch=5, batch_idx=0)
+        metric_node.forward(decisions, targets, ctx_val, logits=inverted)
+
+        # TEST epoch 5: aligned logits should yield AP ≈ 1, not a polluted average.
+        ctx_test = Context(stage=ExecutionStage.TEST, epoch=5, batch_idx=0)
+        out = metric_node.forward(decisions, targets, ctx_test, logits=aligned)
+        ap = next(m.value for m in out["metrics"] if m.name == "average_precision")
+        assert ap > 0.99
+
+    def test_ap_all_negative_targets_returns_finite(self):
+        """All-negative targets is degenerate; histogram-mode AP returns 0.0 finitely.
+
+        AP is undefined with no positive class. torchmetrics' histogram-mode
+        BinaryAveragePrecision returns 0.0 (sort-mode returns NaN). Either is
+        acceptable as long as the call does not crash and the returned value
+        is finite or NaN — log consumers should treat both as "no signal".
+        """
+        metric_node = AnomalyDetectionMetrics()
+        b, h, w = 1, 8, 8
+        targets = torch.zeros(b, h, w, 1).bool()
+        decisions = torch.zeros(b, h, w, 1).bool()
+        logits = torch.randn(b, h, w, 1)
+        ctx = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=0)
+        out = metric_node.forward(decisions, targets, ctx, logits=logits)
+        ap = next(m.value for m in out["metrics"] if m.name == "average_precision")
+        assert math.isnan(ap) or ap == 0.0
+
+    def test_ap_thresholds_constructor(self):
+        """ap_thresholds kwarg controls the histogram resolution."""
+        metric_node = AnomalyDetectionMetrics(ap_thresholds=50)
+        assert metric_node.ap_thresholds == 50
+        confmat = metric_node.average_precision_metric.confmat
+        assert confmat.numel() == 50 * 4
 
 
 class TestScoreStatisticsMetric:

--- a/uv.lock
+++ b/uv.lock
@@ -1556,11 +1556,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4804,18 +4804,18 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:d76f08e212285bd84c4c5a3472417f8eb4ee72e4067a604f7508dbfa2119771f", upload-time = "2026-04-27T17:36:45Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c9a7ca4c74fae10a58e6175b4b2cea953f9322bb6562bbf339ad6a05f52190ad", upload-time = "2026-04-27T17:37:32Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:90ef0c2454e5296a9fb021ddd42252e4ce1abe2c0a4988a173ef90a6cded0bf5", upload-time = "2026-04-27T17:39:29Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:7c78215c3af4f62e63f2b2e360f1722fc719b0853c7ac22666483d9810613a4c", upload-time = "2026-04-27T17:43:49Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:6f367e62fd81b75cdf23ca4b75ced834d2db2cf98d1588ac935bde345de9de23", upload-time = "2026-04-27T17:48:09Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:c2a5984deba8e001d166bf9cb83b8351f63a28b009e1a2fa0e4bbf08c90b259b", upload-time = "2026-04-27T17:52:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", upload-time = "2026-04-27T17:36:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = "2026-04-27T17:37:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp311-cp311-win_amd64.whl", upload-time = "2026-04-27T17:39:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2026-04-27T17:41:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-04-27T17:42:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-win_amd64.whl", upload-time = "2026-04-27T17:43:49Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2026-04-27T17:45:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", upload-time = "2026-04-27T17:46:18Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-win_amd64.whl", upload-time = "2026-04-27T17:48:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2026-04-27T17:50:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", upload-time = "2026-04-27T17:50:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-win_amd64.whl", upload-time = "2026-04-27T17:52:32Z" },
 ]
 
 [[package]]
@@ -4862,18 +4862,18 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ed1324dbbbecb5a0149ed4ce8f9308465a1eef85ca2d2370dbb14805bf1c90aa", upload-time = "2026-04-09T23:21:34Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:8f2629d056570c929b0a1d5473d9cb0320b90bda1764bda353553a72cc6b2069", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:d26091b15cd6e3c74c148d9b68c9a901ad6fb9b0f66fa3ea3ab09f04132a07d3", upload-time = "2026-04-09T23:21:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:8c0d1c4fbb2c9a4d5d41d0aaa87da20e525bcb2a154ce405725b0be59456804b", upload-time = "2026-04-09T23:21:36Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:0232cb219927a52d6c98ff202f32d1cdf4802c2195a85fc1f1a0c1b0b4983a4d", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:367d42ea703844ecdb516e9d5eb09929012a58705d2622cf4e9e3c37f278cb85", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", upload-time = "2026-04-09T23:21:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp311-cp311-win_amd64.whl", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-win_amd64.whl", upload-time = "2026-04-09T23:21:36Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2026-04-09T23:21:37Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-win_amd64.whl", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-win_amd64.whl", upload-time = "2026-04-09T23:21:39Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Splits the AP-metric memory leak fix out of #16 so it can merge independently of the multi-file Lentils dataset refactor.
- Single-file behaviour change: `AnomalyDetectionMetrics.average_precision_metric` now uses bounded-thresholds AP and resets per epoch.

## Why
Without this, `BinaryAveragePrecision` accumulates GPU preds/targets unboundedly across every batch and every epoch. Reproduced OOM on a 16 GiB card around epoch 8–9 on the lentils Dinomaly v2 run.

## What changed
- `cuvis_ai/node/metrics.py`: ctor arg `ap_thresholds` (default 200) → `BinaryAveragePrecision(thresholds=...)`. Explicit `update()` / `compute()` / `reset()` lifecycle gated on a `(stage, epoch)` boundary tracker.
- `tests/training/test_metrics.py`: bounded-state + per-epoch-reset coverage (~130 new lines).
- `CHANGELOG.md`: entry added under a new `## [Unreleased]` heading (not retroactively edited into 0.5.0).
- `uv.lock`: bumped `idna` 3.13 → 3.16 to clear pip-audit `CVE-2026-45409`; dropped sha256 hashes from `torch` and `torchvision` wheel entries to stop spurious lock churn from PyTorch-index re-publishes.

## Test plan
- [x] CI `uv run pytest tests/training/test_metrics.py -q` green.
- [x] Lentils Dinomaly v2 50-epoch run on 16 GiB GPU no longer OOMs at epoch 8–9 (already verified during PR #16 development).
- [x] AP values across the run match within float tolerance vs the unpatched implementation on shorter runs.

## Notes
Extracted from #16 per @nimaghorbani's review request so it can land first. The fix is commit `c143895` from PR #16's history — same content, just on its own branch off `main`. Will rebase PR #16 onto main after this lands so the AP commit drops out of that PR's history.