### PR TITLE
fix(docs): remove hijacked polyfill.io from the docs site

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,63 @@
+name: Redeploy docs (manual)
+
+# Docs-only republish of the GitHub Pages site, decoupled from the PyPI release
+# pipeline. Use to refresh the `latest` docs without cutting a release — e.g.
+# after a docs-only fix. Mirrors the deploy-docs job in pypi-release.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to (re)deploy as `latest` (e.g. 0.7.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy-docs:
+    name: Redeploy Documentation to gh-pages
+    runs-on: ubuntu-latest
+    container:
+      image: cubertgmbh/cuvis_pyil:3.5.0-ubuntu24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full history for mike
+
+      - name: Mark workspace as safe for Git versioning
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install documentation dependencies
+        run: uv sync --locked --extra docs
+
+      - name: Install system dependencies for OpenCV / ffmpeg imports
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends libgl1 libglib2.0-0 ffmpeg
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Configure git for deployment
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy documentation with mike
+        run: |
+          uv run mike deploy --push --update-aliases "${{ inputs.version }}" latest
+          uv run mike set-default --push latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- **Security/docs:** removed the `https://polyfill.io/v3/polyfill.min.js` include from `mkdocs.yml`. The `polyfill.io` domain is hijacked and was injecting a credential-phishing "Sign in" prompt on the docs site; MathJax 3 needs no polyfill on supported browsers. Added a `Redeploy docs (manual)` workflow (`workflow_dispatch` with a version input) so the gh-pages site can be republished without cutting a PyPI release.
 - Fixed `AnomalyDetectionMetrics` average precision: switched to histogram-based `BinaryAveragePrecision(thresholds=N)` so state is bounded by construction, and reset only on `(stage, epoch)` boundaries so the metric accumulates across batches via `update()` within a validation epoch — the per-batch emitted value is a running AP that converges to true epoch-level AP, instead of a leak-prone cumulative or a noisy per-batch AP.
 
 ## 0.7.3 - 2026-05-18

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -262,7 +262,6 @@ extra_css:
 # JavaScript
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js
   - javascripts/mermaid-theme.js


### PR DESCRIPTION
## Problem — live security issue on docs.cuvis.ai

The docs site loads `https://polyfill.io/v3/polyfill.min.js` (old MathJax ES6 polyfill) from `mkdocs.yml`. The `polyfill.io` domain is a hijacked supply-chain dependency and is currently injecting a credential-phishing "Sign in" popup on the live site.

## Fix

- **Remove** the `polyfill.io` `extra_javascript` entry. MathJax 3 needs no polyfill on supported browsers; MathJax/Mermaid loading is otherwise unchanged.
- **Add** `.github/workflows/deploy-docs.yml` — a `Redeploy docs (manual)` `workflow_dispatch` (version input) that republishes the gh-pages docs, mirroring the deploy-docs job in `pypi-release.yml`, so the live site can be refreshed without cutting a PyPI release.

## After merge (clears the live popup)

Run **Actions → "Redeploy docs (manual)"** with the current docs version (e.g. the latest released version) to republish `docs.cuvis.ai` without the polyfill.io include.
