### PR TITLE
feat(node): generalize FixedWavelengthSelector to n-channel output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,12 +117,7 @@ jobs:
 
       - name: Run pip-audit for vulnerabilities
         run: |
-          uv run pip-audit --desc on --skip-editable \
-            --ignore-vuln PYSEC-2022-42969 \
-            --ignore-vuln CVE-2025-71176 \
-            --ignore-vuln CVE-2026-34993 \
-            --ignore-vuln CVE-2026-47265 \
-            --ignore-vuln PYSEC-2026-196
+          uv run pip-audit --desc on --skip-editable --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176
 
       - name: Run detect-secrets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,12 @@ jobs:
 
       - name: Run pip-audit for vulnerabilities
         run: |
-          uv run pip-audit --desc on --skip-editable --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176
+          uv run pip-audit --desc on --skip-editable \
+            --ignore-vuln PYSEC-2022-42969 \
+            --ignore-vuln CVE-2025-71176 \
+            --ignore-vuln CVE-2026-34993 \
+            --ignore-vuln CVE-2026-47265 \
+            --ignore-vuln PYSEC-2026-196
 
       - name: Run detect-secrets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for setuptools-scm
 
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -202,7 +202,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for setuptools-scm
 

--- a/.github/workflows/dep_compat.yml
+++ b/.github/workflows/dep_compat.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for mike
 

--- a/.github/workflows/plugin-runtime-smoke.yml
+++ b/.github/workflows/plugin-runtime-smoke.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -237,7 +237,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for mike
 

--- a/.github/workflows/registry_compat.yml
+++ b/.github/workflows/registry_compat.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.10.0 - 2026-06-24
+
+- **`FixedWavelengthSelector` generalized to n-channel output.** `OUTPUT_SPECS["rgb_image"]` is
+  relaxed to `(-1, -1, -1, -1)` and `target_wavelengths` accepts any tuple of length `>= 1`, so the
+  node can emit any number of bands (e.g. a 6-channel VIS+SWIR stack) instead of exactly three. The
+  3-channel default and its running/gamma normalization path are unchanged; `STATISTICAL` /
+  `RUNNING` normalization stays 3-channel only and raises for `n != 3`, while `per_frame` works for
+  any `n`. The contract stays tight on `ChannelSelectorBase` (the 11 fixed-3-channel selectors keep
+  their `(-1, -1, -1, 3)` validation); only `FixedWavelengthSelector` overrides it.
+- **Added `PercentileNormalizer` and `DisplayNormalizer`.** Per-channel percentile / min-max
+  normalization for any channel count (`per_frame`, `running`, or `statistical` modes), plus a thin
+  stateless sRGB gamma step, factored out of `ChannelSelectorBase` so a selector can be a pure
+  band-picker and normalization composes downstream. `NormMode` moves to `normalization.py` and is
+  re-exported from `channel_selector` for backward compatibility. Both nodes are registered in the
+  built-in catalog.
+
 ## 0.9.0 - 2026-06-23
 
 - **Trainrun configs reference their pipeline by path.** Following the schemas/core change to a `pipeline:` reference, the bundled trainrun configs no longer inline or Hydra-compose a pipeline: the twelve `@pipeline`-group configs drop that `defaults` entry for a top-level `pipeline: ../pipeline/<group>/<name>.yaml` reference, and the two resolved snapshot configs (`drcnn_adaclip_trainrun`, `adaclip_cir_false_color_optimal_threshold`) extract their inline pipeline to a `<name>_pipeline.yaml` sibling and reference it. The migration-equivalence test now also asserts every string `pipeline` reference resolves to a loadable `PipelineConfig`. Script-driven configs that use `pipeline:` as a parameter-override mapping are unchanged.

--- a/configs/plugins/cuvis_ai_builtin.yaml
+++ b/configs/plugins/cuvis_ai_builtin.yaml
@@ -550,7 +550,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -577,7 +577,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -604,7 +604,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -631,7 +631,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -658,7 +658,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -683,15 +683,15 @@ capabilities:
   output_specs:
     rgb_image:
       dtype: float32
-      shape: [-1, -1, -1, 3]
+      shape: [-1, -1, -1, -1]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed image [B, H, W, C] in 0-1 range. C == 3 for the standard RGB default; C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.
     band_info:
       dtype: ''
       shape: []
       optional: false
       description: Selected band metadata
-  doc_summary: Fixed wavelength band selection (e.g., 650, 550, 450 nm).
+  doc_summary: Fixed wavelength band selection — picks the nearest band for each target wavelength.
 - class_name: cuvis_ai.node.channel_selector.HighContrastSelector
   category: transform
   tags: [dim_reduction, hyperspectral, numpy, preprocessing]
@@ -712,7 +712,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -739,7 +739,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -771,7 +771,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -825,7 +825,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -857,7 +857,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -889,7 +889,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -921,7 +921,7 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 3]
       optional: false
-      description: Composed RGB image [B, H, W, 3] in 0-1 range
+      description: Composed RGB image [B, H, W, 3] in 0-1 range.
     band_info:
       dtype: ''
       shape: []
@@ -1768,6 +1768,23 @@ capabilities:
       description: Optional list of Metric objects to log
       variadic: true
   doc_summary: TensorBoard monitoring node for logging artifacts and metrics.
+- class_name: cuvis_ai.node.normalization.DisplayNormalizer
+  category: transform
+  tags: [normalization, numpy, preprocessing]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#6FAE5C\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M52 26a20 20 0 0 0-36 0\"/>\r\n  <path d=\"M52 16v10h-10\"/>\r\n  <path d=\"M12 38a20 20 0 0 0 36 0\"/>\r\n  <path d=\"M12 48v-10h10\"/>\r\n</svg>\r\n"
+  input_specs:
+    data:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Input data tensor to normalize (BHWC format)
+  output_specs:
+    normalized:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Normalized output tensor
+  doc_summary: Apply sRGB gamma companding (IEC 61966-2-1) to a ``[0, 1]`` BHWC tensor.
 - class_name: cuvis_ai.node.normalization.IdentityNormalizer
   category: transform
   tags: [normalization, numpy, preprocessing]
@@ -1802,6 +1819,23 @@ capabilities:
       optional: false
       description: Normalized output tensor
   doc_summary: Min-max normalization per sample and channel (keeps gradients).
+- class_name: cuvis_ai.node.normalization.PercentileNormalizer
+  category: transform
+  tags: [normalization, numpy, preprocessing]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#6FAE5C\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M52 26a20 20 0 0 0-36 0\"/>\r\n  <path d=\"M52 16v10h-10\"/>\r\n  <path d=\"M12 38a20 20 0 0 0 36 0\"/>\r\n  <path d=\"M12 48v-10h10\"/>\r\n</svg>\r\n"
+  input_specs:
+    data:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Input data tensor to normalize (BHWC format)
+  output_specs:
+    normalized:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Normalized output tensor
+  doc_summary: Per-channel normalization to ``[0, 1]`` for BHWC data of any channel count.
 - class_name: cuvis_ai.node.normalization.PerPixelUnitNorm
   category: transform
   tags: [normalization, numpy, preprocessing]

--- a/cuvis_ai/node/__init__.py
+++ b/cuvis_ai/node/__init__.py
@@ -53,7 +53,13 @@ from cuvis_ai.node.json_file import (
 from cuvis_ai.node.labels import BinaryAnomalyLabelMapper
 from cuvis_ai.node.losses import DistinctnessLoss, ForegroundContrastLoss
 from cuvis_ai.node.mask_ops import MaskRobustifier, MaskToBBoxKalman
-from cuvis_ai.node.normalization import IdentityNormalizer, MinMaxNormalizer, SigmoidNormalizer
+from cuvis_ai.node.normalization import (
+    DisplayNormalizer,
+    IdentityNormalizer,
+    MinMaxNormalizer,
+    PercentileNormalizer,
+    SigmoidNormalizer,
+)
 from cuvis_ai.node.numpy_file import NpyReader, NumpyFeatureWriterNode
 from cuvis_ai.node.occlusion import (
     OcclusionNodeBase,
@@ -105,6 +111,7 @@ __all__ = [
     "DetectionCocoJsonNode",
     "DetectionJsonReader",
     "DecisionToMask",
+    "DisplayNormalizer",
     "DistinctnessLoss",
     "FixedWavelengthSelector",
     "ForegroundContrastLoss",
@@ -130,6 +137,7 @@ __all__ = [
     "PoissonOcclusionNode",
     "PCA",
     "PCAVisualization",
+    "PercentileNormalizer",
     "PipelineComparisonVisualizer",
     "RangeAverageFalseRGBSelector",
     "RGBAnomalyMask",

--- a/cuvis_ai/node/channel_selector.py
+++ b/cuvis_ai/node/channel_selector.py
@@ -137,8 +137,10 @@ class ChannelSelectorBase(Node):
     OUTPUT_SPECS = {
         "rgb_image": PortSpec(
             dtype=torch.float32,
-            shape=(-1, -1, -1, 3),
-            description="Composed RGB image [B, H, W, 3] in 0-1 range",
+            shape=(-1, -1, -1, -1),
+            description="Composed image [B, H, W, C] in 0-1 range. "
+                        "C == 3 for standard RGB selectors; "
+                        "C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.",
         ),
         "band_info": PortSpec(
             dtype=dict,
@@ -584,19 +586,25 @@ class NDVISelector(_NormalizedDifferenceIndexBase):
 
 
 class FixedWavelengthSelector(ChannelSelectorBase):
-    """Fixed wavelength band selection (e.g., 650, 550, 450 nm).
+    """Fixed wavelength band selection — picks the nearest band for each target wavelength.
 
-    Selects bands nearest to the specified target wavelengths for R, G, B channels.
-    This is the simplest band selection strategy that produces "true color-ish" images.
+    For the standard 3-channel case (default) this produces a "true color-ish" RGB image.
+    For ``n > 3`` target wavelengths the node stacks ``n`` bands into a
+    ``[B, H, W, n]`` output — useful for multi-channel hyperspectral models (e.g.
+    a 6-channel VIS+SWIR input to a Dinomaly detector).
 
     Parameters
     ----------
-    target_wavelengths : tuple[float, float, float]
-        Target wavelengths for R, G, B channels in nanometers.
-        Default: (650.0, 550.0, 450.0)
+    target_wavelengths : tuple[float, ...]
+        Target wavelengths in nanometers, in the order they should be stacked.
+        Must contain at least one wavelength.
+        Default: (650.0, 550.0, 450.0) — standard false-RGB.
     normalize_output : bool
-        If ``True`` (default), apply selector normalization to produce 0-1 RGB output.
-        If ``False``, return raw selected band values without normalization/gamma.
+        If ``True`` (default), apply selector normalization to produce a 0–1 output.
+        Normalization (running bounds + optional sRGB gamma) is only available for
+        the 3-channel case (``len(target_wavelengths) == 3``).  For ``n != 3`` with
+        ``normalize_output=True`` the bands are stacked without normalization and a
+        warning is emitted — pass ``normalize_output=False`` to suppress it.
     """
 
     _category = NodeCategory.TRANSFORM
@@ -606,10 +614,15 @@ class FixedWavelengthSelector(ChannelSelectorBase):
 
     def __init__(
         self,
-        target_wavelengths: tuple[float, float, float] = (650.0, 550.0, 450.0),
+        target_wavelengths: tuple[float, ...] = (650.0, 550.0, 450.0),
         normalize_output: bool = True,
         **kwargs,
     ) -> None:
+        target_wavelengths = tuple(float(w) for w in target_wavelengths)
+        if len(target_wavelengths) < 1:
+            raise ValueError(
+                "FixedWavelengthSelector: target_wavelengths must contain at least one wavelength"
+            )
         super().__init__(
             target_wavelengths=target_wavelengths,
             normalize_output=normalize_output,
@@ -651,10 +664,24 @@ class FixedWavelengthSelector(ChannelSelectorBase):
         # Find nearest bands
         indices = [self._nearest_band_index(wavelengths_np, nm) for nm in self.target_wavelengths]
 
-        # Compose RGB, optionally bypassing selector normalization.
-        if self.normalize_output:
+        # Compose output, optionally applying selector normalization.
+        # Normalization (running bounds + gamma) requires exactly 3 channels because
+        # _normalize_rgb's running buffers are 3-element and its quantile paths
+        # hard-reshape to (-1, 3). For n != 3 we stack raw bands; if the caller
+        # also requested normalize_output=True we emit a warning so they know.
+        n = len(self.target_wavelengths)
+        if self.normalize_output and n == 3:
             rgb = self._compose_rgb(cube, indices)
         else:
+            if self.normalize_output and n != 3:
+                from loguru import logger
+                logger.warning(
+                    "FixedWavelengthSelector: normalize_output=True is only supported for "
+                    "3-channel selection; got {} target wavelengths. "
+                    "Returning raw stacked bands without normalization. "
+                    "Pass normalize_output=False to suppress this warning.",
+                    n,
+                )
             bands = [cube[..., idx] for idx in indices]
             rgb = torch.stack(bands, dim=-1)
 

--- a/cuvis_ai/node/channel_selector.py
+++ b/cuvis_ai/node/channel_selector.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from enum import StrEnum
 from typing import Any, Literal
 
 import numpy as np
@@ -64,16 +63,15 @@ from sklearn.metrics import roc_auc_score
 from torch import Tensor
 
 from cuvis_ai.node.colormap import render_scalar_hsv_colormap
+from cuvis_ai.node.normalization import NormMode
 from cuvis_ai.utils.welford import WelfordAccumulator
 from cuvis_ai_core.node import Node
 
-
-class NormMode(StrEnum):
-    """RGB normalization mode for channel selectors."""
-
-    PER_FRAME = "per_frame"
-    RUNNING = "running"
-    STATISTICAL = "statistical"
+# ``NormMode`` now lives in :mod:`cuvis_ai.node.normalization` alongside
+# ``PercentileNormalizer`` / ``DisplayNormalizer``; it is re-exported here so the
+# in-selector normalization API stays backward compatible. New pipelines should
+# stack a ``PercentileNormalizer`` (+ ``DisplayNormalizer`` for false-RGB) after
+# the selector instead of relying on the selector's built-in normalization.
 
 
 class ChannelSelectorBase(Node):

--- a/cuvis_ai/node/channel_selector.py
+++ b/cuvis_ai/node/channel_selector.py
@@ -139,8 +139,8 @@ class ChannelSelectorBase(Node):
             dtype=torch.float32,
             shape=(-1, -1, -1, -1),
             description="Composed image [B, H, W, C] in 0-1 range. "
-                        "C == 3 for standard RGB selectors; "
-                        "C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.",
+            "C == 3 for standard RGB selectors; "
+            "C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.",
         ),
         "band_info": PortSpec(
             dtype=dict,
@@ -675,6 +675,7 @@ class FixedWavelengthSelector(ChannelSelectorBase):
         else:
             if self.normalize_output and n != 3:
                 from loguru import logger
+
                 logger.warning(
                     "FixedWavelengthSelector: normalize_output=True is only supported for "
                     "3-channel selection; got {} target wavelengths. "

--- a/cuvis_ai/node/channel_selector.py
+++ b/cuvis_ai/node/channel_selector.py
@@ -58,6 +58,7 @@ import torch.nn.functional as F
 from cuvis_ai_schemas.enums import NodeCategory, NodeTag
 from cuvis_ai_schemas.execution import Context, InputStream
 from cuvis_ai_schemas.pipeline import PortSpec
+from loguru import logger
 from scipy.ndimage import laplace
 from sklearn.metrics import roc_auc_score
 from torch import Tensor
@@ -111,7 +112,13 @@ class ChannelSelectorBase(Node):
             Wavelength array in nanometers.
     OUTPUT_SPECS
         ``rgb_image`` : float32, shape (-1, -1, -1, 3)
-            Composed RGB image in BHWC format (0-1 range).
+            Composed RGB image in BHWC format (0-1 range). Subclasses that emit
+            a different channel count (e.g. :class:`FixedWavelengthSelector`
+            with ``n != 3``) must override ``OUTPUT_SPECS`` to widen the channel
+            dimension; the base class keeps the tight 3-channel contract so
+            pipeline validation catches accidental mis-wiring of the standard
+            RGB selectors (``FastRGBSelector``, ``RangeAverageFalseRGBSelector``,
+            ``CIRSelector``, ``CIETristimulusRGBSelector``, NDVI variants, …).
         ``band_info`` : dict
             Metadata about selected bands.
     """
@@ -137,10 +144,8 @@ class ChannelSelectorBase(Node):
     OUTPUT_SPECS = {
         "rgb_image": PortSpec(
             dtype=torch.float32,
-            shape=(-1, -1, -1, -1),
-            description="Composed image [B, H, W, C] in 0-1 range. "
-            "C == 3 for standard RGB selectors; "
-            "C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.",
+            shape=(-1, -1, -1, 3),
+            description="Composed RGB image [B, H, W, 3] in 0-1 range.",
         ),
         "band_info": PortSpec(
             dtype=dict,
@@ -602,9 +607,24 @@ class FixedWavelengthSelector(ChannelSelectorBase):
     normalize_output : bool
         If ``True`` (default), apply selector normalization to produce a 0–1 output.
         Normalization (running bounds + optional sRGB gamma) is only available for
-        the 3-channel case (``len(target_wavelengths) == 3``).  For ``n != 3`` with
-        ``normalize_output=True`` the bands are stacked without normalization and a
-        warning is emitted — pass ``normalize_output=False`` to suppress it.
+        the 3-channel case (``len(target_wavelengths) == 3``). For ``n != 3`` the
+        bands are stacked raw regardless of this flag; a single warning is emitted
+        at construction so callers know to pass ``normalize_output=False`` to silence
+        it. ``norm_mode`` settings of ``running`` / ``statistical`` rely on
+        3-element running buffers and a hard ``reshape(-1, 3)`` and are therefore
+        rejected at construction for ``n != 3`` — pass ``norm_mode="per_frame"``
+        (the only mode the n-channel path supports today).
+
+    Ports
+    -----
+    OUTPUT_SPECS
+        ``rgb_image`` : float32, shape ``(-1, -1, -1, -1)``
+            Stacked selected bands ``[B, H, W, len(target_wavelengths)]``.
+            Port name kept as ``rgb_image`` for graph compatibility with
+            downstream consumers. For the 3-channel default the output is the
+            normalised RGB image; for ``n != 3`` it is the raw stacked bands.
+        ``band_info`` : dict
+            See ``forward`` for keys.
     """
 
     _category = NodeCategory.TRANSFORM
@@ -612,17 +632,54 @@ class FixedWavelengthSelector(ChannelSelectorBase):
         {NodeTag.HYPERSPECTRAL, NodeTag.DIM_REDUCTION, NodeTag.PREPROCESSING, NodeTag.NUMPY}
     )
 
+    # Override the base class's tight 3-channel contract so this selector can
+    # emit an n-channel stack. Keep the rest of the base spec dict intact.
+    OUTPUT_SPECS = {
+        **ChannelSelectorBase.OUTPUT_SPECS,
+        "rgb_image": PortSpec(
+            dtype=torch.float32,
+            shape=(-1, -1, -1, -1),
+            description="Composed image [B, H, W, C] in 0-1 range. "
+            "C == 3 for the standard RGB default; "
+            "C == len(target_wavelengths) for FixedWavelengthSelector with n > 3.",
+        ),
+    }
+
     def __init__(
         self,
         target_wavelengths: tuple[float, ...] = (650.0, 550.0, 450.0),
         normalize_output: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         target_wavelengths = tuple(float(w) for w in target_wavelengths)
         if len(target_wavelengths) < 1:
             raise ValueError(
                 "FixedWavelengthSelector: target_wavelengths must contain at least one wavelength"
             )
+        n = len(target_wavelengths)
+
+        # The base class's running/statistical normalisation machinery assumes a
+        # 3-channel output: running_min/running_max are 3-element buffers, and
+        # statistical_initialization / _running_normalize do `reshape(-1, 3)`.
+        # For n != 3 those modes either silently mix unrelated channels (e.g.
+        # n=6 reshapes into (-1, 3) and pairs c0+c3, c1+c4, c2+c5 per row), or
+        # raise RuntimeError on non-divisible totals (n=4). Reject them at
+        # construction so the failure mode is obvious. ``per_frame`` (which
+        # operates only on the forward path's branch below) is the only mode
+        # supported for the n != 3 case today.
+        norm_mode_arg = kwargs.get("norm_mode", NormMode.RUNNING)
+        norm_mode_resolved = NormMode(
+            str(norm_mode_arg) if isinstance(norm_mode_arg, NormMode) else norm_mode_arg
+        )
+        if n != 3 and norm_mode_resolved in (NormMode.STATISTICAL, NormMode.RUNNING):
+            raise ValueError(
+                f"FixedWavelengthSelector: norm_mode={norm_mode_resolved.value!r} requires "
+                f"exactly 3 target wavelengths (got n={n}). The running/statistical paths "
+                f"rely on 3-element buffers and reshape(-1, 3). Pass "
+                f"norm_mode='per_frame' (the only mode supported for n != 3) or use "
+                f"len(target_wavelengths) == 3."
+            )
+
         super().__init__(
             target_wavelengths=target_wavelengths,
             normalize_output=normalize_output,
@@ -630,6 +687,23 @@ class FixedWavelengthSelector(ChannelSelectorBase):
         )
         self.target_wavelengths = target_wavelengths
         self.normalize_output = bool(normalize_output)
+
+        # Whether the forward path will actually normalise. The band_info flag
+        # downstream MUST mirror this — `normalize_output=True` with n != 3
+        # silently returns raw bands, so any consumer that trusts the flag
+        # would skip a normalisation it still needs.
+        self._effective_normalize_output = self.normalize_output and n == 3
+
+        # Warn ONCE at construction (not per forward call — n and
+        # normalize_output are both known here and don't change later).
+        if self.normalize_output and n != 3:
+            logger.warning(
+                "FixedWavelengthSelector: normalize_output=True is only supported for "
+                "3-channel selection; got {} target wavelengths. The forward path will "
+                "return raw stacked bands; pass normalize_output=False to suppress this "
+                "warning.",
+                n,
+            )
 
     def _compute_raw_rgb(self, cube: torch.Tensor, wavelengths: Any) -> torch.Tensor:
         """Select the nearest spectral band for each target wavelength."""
@@ -664,34 +738,26 @@ class FixedWavelengthSelector(ChannelSelectorBase):
         # Find nearest bands
         indices = [self._nearest_band_index(wavelengths_np, nm) for nm in self.target_wavelengths]
 
-        # Compose output, optionally applying selector normalization.
-        # Normalization (running bounds + gamma) requires exactly 3 channels because
-        # _normalize_rgb's running buffers are 3-element and its quantile paths
-        # hard-reshape to (-1, 3). For n != 3 we stack raw bands; if the caller
-        # also requested normalize_output=True we emit a warning so they know.
-        n = len(self.target_wavelengths)
-        if self.normalize_output and n == 3:
+        # 3-channel path goes through the (running / statistical / per-frame)
+        # normalisation machinery in ChannelSelectorBase. For n != 3 we always
+        # stack raw bands — the construction-time guard guarantees we only see
+        # `per_frame` mode here, and the n != 3 + normalize_output=True warning
+        # was emitted once in __init__.
+        if self._effective_normalize_output:
             rgb = self._compose_rgb(cube, indices)
         else:
-            if self.normalize_output and n != 3:
-                from loguru import logger
-
-                logger.warning(
-                    "FixedWavelengthSelector: normalize_output=True is only supported for "
-                    "3-channel selection; got {} target wavelengths. "
-                    "Returning raw stacked bands without normalization. "
-                    "Pass normalize_output=False to suppress this warning.",
-                    n,
-                )
             bands = [cube[..., idx] for idx in indices]
             rgb = torch.stack(bands, dim=-1)
 
+        n = len(self.target_wavelengths)
         band_info = {
-            "strategy": "baseline_false_rgb",
+            "strategy": "baseline_false_rgb" if n == 3 else "stacked_bands",
             "band_indices": indices,
             "band_wavelengths_nm": [float(wavelengths_np[i]) for i in indices],
             "target_wavelengths_nm": list(self.target_wavelengths),
-            "normalized_output": self.normalize_output,
+            # Mirror what actually happened — `normalize_output=True` with
+            # n != 3 returns raw bands, so this MUST be False there.
+            "normalized_output": self._effective_normalize_output,
         }
 
         return {"rgb_image": rgb, "band_info": band_info}

--- a/cuvis_ai/node/normalization.py
+++ b/cuvis_ai/node/normalization.py
@@ -32,24 +32,42 @@ All normalizers expect BHWC input format. For HWC tensors, add batch dimension:
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
 
 import torch
 from cuvis_ai_schemas.enums import NodeCategory, NodeTag
+from cuvis_ai_schemas.execution import InputStream
 from cuvis_ai_schemas.pipeline import PortSpec
 from torch import Tensor
 
 from cuvis_ai_core.node import Node
 
 
+class NormMode(StrEnum):
+    """Normalization mode for percentile-based normalizers.
+
+    Shared by :class:`PercentileNormalizer` and the channel selectors in
+    :mod:`cuvis_ai.node.channel_selector` (which re-exports this enum).
+    """
+
+    PER_FRAME = "per_frame"
+    RUNNING = "running"
+    STATISTICAL = "statistical"
+
+
 class _ScoreNormalizerBase(Node):
-    """Base class for differentiable score normalizers operating on BHWC tensors.
+    """Base class for BHWC normalization nodes.
 
     Notes
     -----
     All normalization nodes in this module expect inputs in BHWC format
     ([batch, height, width, channels]). Callers are responsible for adding
     a batch dimension when working with HWC tensors (use `x.unsqueeze(0)`).
+
+    Most subclasses are differentiable, but some keep fitted statistical state
+    (e.g. :class:`MinMaxNormalizer` with running stats, :class:`PercentileNormalizer`)
+    and update it under ``no_grad`` during ``forward``.
     """
 
     _category = NodeCategory.TRANSFORM
@@ -504,9 +522,234 @@ class PerPixelUnitNorm(_ScoreNormalizerBase):
         return normalized
 
 
+class PercentileNormalizer(_ScoreNormalizerBase):
+    """Per-channel normalization to ``[0, 1]`` for BHWC data of any channel count.
+
+    Extracted from ``ChannelSelectorBase`` so band selection and display
+    normalization are separate, composable steps. Operates on any channel count
+    ``C`` (fixed at construction via ``n_channels``). Does **not** apply sRGB
+    gamma; chain :class:`DisplayNormalizer` after it for the false-RGB display
+    path. ML / n-channel callers use this node alone.
+
+    Modes (``norm_mode``):
+
+    - ``per_frame``: per-batch, per-channel absolute min/max; no inter-frame state.
+    - ``statistical``: global percentile bounds precomputed via ``StatisticalTrainer``.
+    - ``running`` (default): the first ``running_warmup_frames`` frames use per-frame
+      percentile normalization while accumulating global percentile bounds (min-of-lows,
+      max-of-highs); afterwards those bounds are used, frozen after
+      ``freeze_running_bounds_after_frames`` calls. Bounds update on every call including
+      inference, which live false-RGB video relies on; the freeze guards late drift.
+
+    Parameters
+    ----------
+    n_channels : int
+        Channel count ``C`` of the input. Sizes the per-channel bound buffers.
+    norm_mode : str | NormMode
+        Normalization mode. Default ``running``.
+    freeze_running_bounds_after_frames : int | None
+        Stop updating ``running`` bounds after this many calls. Default ``20``;
+        ``None`` keeps unbounded accumulation.
+    running_warmup_frames : int
+        Frames to normalize per-frame while accumulating bounds. Default ``10``.
+    quantile_low, quantile_high : float
+        Percentile bounds (fractions) for ``running`` / ``statistical`` modes.
+        Default ``0.005`` / ``0.995``.
+    eps : float
+        Floor for the ``(max - min)`` denominator. Default ``1e-8``.
+
+    Ports
+    -----
+    INPUT_SPECS
+        ``data`` : float32, shape (-1, -1, -1, -1), BHWC tensor with ``C == n_channels``.
+    OUTPUT_SPECS
+        ``normalized`` : float32, shape (-1, -1, -1, -1), same shape, values in ``[0, 1]``.
+    """
+
+    _category = NodeCategory.TRANSFORM
+    _tags = frozenset({NodeTag.NORMALIZATION, NodeTag.PREPROCESSING, NodeTag.NUMPY})
+
+    def __init__(
+        self,
+        n_channels: int,
+        norm_mode: str | NormMode = NormMode.RUNNING,
+        freeze_running_bounds_after_frames: int | None = 20,
+        running_warmup_frames: int = 10,
+        quantile_low: float = 0.005,
+        quantile_high: float = 0.995,
+        eps: float = 1e-8,
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(n_channels, bool) or not isinstance(n_channels, int) or n_channels < 1:
+            raise ValueError("PercentileNormalizer: n_channels must be an integer >= 1")
+        norm_mode = NormMode(str(norm_mode) if isinstance(norm_mode, NormMode) else norm_mode)
+        if freeze_running_bounds_after_frames is not None and (
+            isinstance(freeze_running_bounds_after_frames, bool)
+            or not isinstance(freeze_running_bounds_after_frames, int)
+            or freeze_running_bounds_after_frames < 1
+        ):
+            raise ValueError("freeze_running_bounds_after_frames must be an integer >= 1 or None")
+        if (
+            isinstance(running_warmup_frames, bool)
+            or not isinstance(running_warmup_frames, int)
+            or running_warmup_frames < 0
+        ):
+            raise ValueError("running_warmup_frames must be an integer >= 0")
+        if not 0.0 <= float(quantile_low) < float(quantile_high) <= 1.0:
+            raise ValueError("PercentileNormalizer: require 0 <= quantile_low < quantile_high <= 1")
+
+        self.n_channels = int(n_channels)
+        self.norm_mode = norm_mode
+        self.freeze_running_bounds_after_frames = freeze_running_bounds_after_frames
+        self.running_warmup_frames = int(running_warmup_frames)
+        self.quantile_low = float(quantile_low)
+        self.quantile_high = float(quantile_high)
+        self.eps = float(eps)
+
+        super().__init__(
+            n_channels=self.n_channels,
+            norm_mode=str(norm_mode),
+            freeze_running_bounds_after_frames=freeze_running_bounds_after_frames,
+            running_warmup_frames=self.running_warmup_frames,
+            quantile_low=self.quantile_low,
+            quantile_high=self.quantile_high,
+            eps=self.eps,
+            **kwargs,
+        )
+
+        # Per-channel bounds + frame counter persist in state_dict (so warmup /
+        # freeze survive a reload) but are deliberately NOT in TRAINABLE_BUFFERS:
+        # they are fitted display statistics, and a gradient-learned bound could
+        # violate lo < hi and turn normalization into an unconstrained transform.
+        self.register_buffer("running_min", torch.full((self.n_channels,), float("nan")))
+        self.register_buffer("running_max", torch.full((self.n_channels,), float("nan")))
+        self.register_buffer("_norm_frame_count", torch.zeros((), dtype=torch.long))
+
+        # Only the statistical path needs a fit pass; running / per_frame do not.
+        self._requires_initial_fit_override = self.norm_mode == NormMode.STATISTICAL
+
+    def _fitted(self) -> bool:
+        """Whether per-channel bounds have been populated (non-NaN)."""
+        return not bool(torch.isnan(self.running_min).any())
+
+    def _per_frame_minmax(self, data: Tensor) -> Tensor:
+        """Per-batch, per-channel absolute min/max to ``[0, 1]``."""
+        lo = data.amin(dim=(1, 2), keepdim=True)
+        hi = data.amax(dim=(1, 2), keepdim=True)
+        denom = (hi - lo).clamp_min(self.eps)
+        return ((data - lo) / denom).clamp_(0.0, 1.0)
+
+    def _per_frame_percentile(self, data: Tensor) -> Tensor:
+        """Per-frame percentile normalization (matches the running quantiles)."""
+        flat = data.reshape(-1, self.n_channels).float()
+        lo = torch.quantile(flat, self.quantile_low, dim=0).view(1, 1, 1, self.n_channels)
+        hi = torch.quantile(flat, self.quantile_high, dim=0).view(1, 1, 1, self.n_channels)
+        denom = (hi - lo).clamp_min(self.eps)
+        return ((data - lo) / denom).clamp_(0.0, 1.0)
+
+    def _apply_bounds(self, data: Tensor) -> Tensor:
+        """Normalize using the accumulated per-channel bounds."""
+        lo = self.running_min.view(1, 1, 1, self.n_channels)
+        hi = self.running_max.view(1, 1, 1, self.n_channels)
+        denom = (hi - lo).clamp_min(self.eps)
+        return ((data - lo) / denom).clamp_(0.0, 1.0)
+
+    @torch.no_grad()
+    def _running_normalize(self, data: Tensor) -> Tensor:
+        """Warmup + min/max percentile accumulation hybrid normalization."""
+        flat = data.reshape(-1, self.n_channels).float()
+        frame_lo = torch.quantile(flat, self.quantile_low, dim=0)
+        frame_hi = torch.quantile(flat, self.quantile_high, dim=0)
+
+        self._norm_frame_count.add_(1)
+        count = int(self._norm_frame_count.item())
+        should_update = (
+            self.freeze_running_bounds_after_frames is None
+            or count <= self.freeze_running_bounds_after_frames
+        )
+        if should_update:
+            if torch.isnan(self.running_min).any():
+                self.running_min.copy_(frame_lo)
+                self.running_max.copy_(frame_hi)
+            else:
+                torch.minimum(self.running_min, frame_lo, out=self.running_min)
+                torch.maximum(self.running_max, frame_hi, out=self.running_max)
+
+        if count <= self.running_warmup_frames:
+            return self._per_frame_percentile(data)
+        return self._apply_bounds(data)
+
+    def _normalize(self, tensor: Tensor) -> Tensor:
+        """Dispatch on ``norm_mode`` (raises on channel mismatch / unfitted statistical)."""
+        if tensor.shape[-1] != self.n_channels:
+            raise ValueError(
+                f"PercentileNormalizer expected {self.n_channels} channels, got {tensor.shape[-1]}"
+            )
+        if self.norm_mode == NormMode.STATISTICAL:
+            if not self._fitted():
+                raise RuntimeError(
+                    "PercentileNormalizer: statistical mode requires "
+                    "statistical_initialization() before forward()"
+                )
+            return self._apply_bounds(tensor)
+        if self.norm_mode == NormMode.RUNNING:
+            return self._running_normalize(tensor)
+        return self._per_frame_minmax(tensor)
+
+    def statistical_initialization(self, input_stream: InputStream) -> None:
+        """Accumulate global per-channel percentile bounds across the dataset.
+
+        Preserves the established min-of-batch-lows / max-of-batch-highs
+        accumulation (batch-order sensitive); a true streaming percentile is a
+        deliberate follow-up, not changed here.
+        """
+        for batch_data in input_stream:
+            data = batch_data["data"]
+            flat = data.reshape(-1, self.n_channels).float()
+            frame_lo = torch.quantile(flat, self.quantile_low, dim=0)
+            frame_hi = torch.quantile(flat, self.quantile_high, dim=0)
+            if torch.isnan(self.running_min).any():
+                self.running_min.copy_(frame_lo)
+                self.running_max.copy_(frame_hi)
+            else:
+                torch.minimum(self.running_min, frame_lo, out=self.running_min)
+                torch.maximum(self.running_max, frame_hi, out=self.running_max)
+        if torch.isnan(self.running_min).any():
+            raise RuntimeError("PercentileNormalizer.statistical_initialization received no data")
+
+
+class DisplayNormalizer(_ScoreNormalizerBase):
+    """Apply sRGB gamma companding (IEC 61966-2-1) to a ``[0, 1]`` BHWC tensor.
+
+    The stateless display-encoding companion to :class:`PercentileNormalizer`:
+    chain it after the normalizer on the false-RGB display path
+    (``selector -> PercentileNormalizer -> DisplayNormalizer``) to lift midtones
+    so images look natural on standard displays. ML / n-channel paths skip it.
+
+    Ports
+    -----
+    INPUT_SPECS
+        ``data`` : float32, shape (-1, -1, -1, -1), BHWC tensor, values in ``[0, 1]``.
+    OUTPUT_SPECS
+        ``normalized`` : float32, shape (-1, -1, -1, -1), sRGB gamma-encoded, ``[0, 1]``.
+    """
+
+    _category = NodeCategory.TRANSFORM
+    _tags = frozenset({NodeTag.NORMALIZATION, NodeTag.PREPROCESSING, NodeTag.NUMPY})
+
+    def _normalize(self, tensor: Tensor) -> Tensor:
+        """sRGB companding: linear ``[0, 1]`` -> gamma-encoded ``[0, 1]``."""
+        low = 12.92 * tensor
+        high = 1.055 * tensor.clamp_min(1e-10).pow(1.0 / 2.4) - 0.055
+        return torch.where(tensor <= 0.0031308, low, high)
+
+
 __all__ = [
+    "DisplayNormalizer",
     "IdentityNormalizer",
     "MinMaxNormalizer",
+    "NormMode",
+    "PercentileNormalizer",
     "SigmoidNormalizer",
     "ZScoreNormalizer",
     "SigmoidTransform",

--- a/tests/node/test_display_normalizer.py
+++ b/tests/node/test_display_normalizer.py
@@ -1,0 +1,50 @@
+"""Tests for DisplayNormalizer (stateless sRGB gamma companding)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cuvis_ai.node.channel_selector import ChannelSelectorBase
+from cuvis_ai.node.normalization import DisplayNormalizer
+
+pytestmark = pytest.mark.unit
+
+
+def test_matches_selector_srgb_gamma() -> None:
+    """Output must equal the selector's _srgb_gamma bit-for-bit."""
+    x = torch.rand(2, 4, 4, 3)
+    out = DisplayNormalizer().forward(data=x)["normalized"]
+    assert torch.allclose(out, ChannelSelectorBase._srgb_gamma(x))
+
+
+def test_unit_range_preserved() -> None:
+    """[0, 1] input stays within [0, 1]."""
+    x = torch.linspace(0.0, 1.0, steps=64).reshape(1, 8, 8, 1).repeat(1, 1, 1, 3)
+    out = DisplayNormalizer().forward(data=x)["normalized"]
+    assert float(out.min()) >= 0.0 and float(out.max()) <= 1.0 + 1e-6
+
+
+def test_lifts_midtones() -> None:
+    """sRGB companding lifts midtones above the linear value."""
+    x = torch.full((1, 2, 2, 3), 0.25)
+    out = DisplayNormalizer().forward(data=x)["normalized"]
+    assert float(out.mean()) > 0.25
+
+
+def test_any_channel_count() -> None:
+    """Gamma is element-wise, so any channel count works."""
+    out = DisplayNormalizer().forward(data=torch.rand(1, 4, 4, 6))["normalized"]
+    assert out.shape == (1, 4, 4, 6)
+
+
+def test_stateless_no_buffers_or_params() -> None:
+    node = DisplayNormalizer()
+    assert list(node.buffers()) == []
+    assert list(node.parameters()) == []
+
+
+def test_differentiable() -> None:
+    x = torch.rand(1, 4, 4, 3, requires_grad=True)
+    DisplayNormalizer().forward(data=x)["normalized"].sum().backward()
+    assert x.grad is not None

--- a/tests/node/test_fixed_wavelength_selector.py
+++ b/tests/node/test_fixed_wavelength_selector.py
@@ -4,9 +4,15 @@ Covers:
 - Backward compat: 3-channel default still works exactly as before
 - n-channel (e.g. 6) band stacking — shape, dtype, correct band pick
 - Empty / single wavelength edge cases
-- normalize_output=True warning for n != 3
-- OUTPUT_SPECS shape relaxed to (-1,-1,-1,-1)
-- ChannelSelectorBase OUTPUT_SPECS shape is (-1,-1,-1,-1)
+- normalize_output=True with n != 3 warns ONCE at construction (not per forward)
+- OUTPUT_SPECS shape (-1,-1,-1,-1) overridden on FixedWavelengthSelector only;
+  the base ChannelSelectorBase stays at the tight (-1,-1,-1,3) contract so the
+  sibling fixed-3-channel selectors keep their pipeline-validation safety net
+- norm_mode={'statistical','running'} is rejected at construction for n != 3
+  (the running/statistical paths assume 3-element buffers + reshape(-1, 3))
+- band_info['normalized_output'] reflects what actually happened
+  (False for n != 3 regardless of the normalize_output flag)
+- band_info['strategy'] = 'baseline_false_rgb' for n==3, 'stacked_bands' otherwise
 """
 
 from __future__ import annotations
@@ -39,18 +45,27 @@ def _wavelengths(n: int = 10, lo: float = 400.0, hi: float = 900.0) -> np.ndarra
 
 
 class TestOutputSpecsShape:
-    def test_base_class_output_spec_is_n_channel(self) -> None:
-        """ChannelSelectorBase.OUTPUT_SPECS must have shape (-1,-1,-1,-1), not (-1,-1,-1,3)."""
+    def test_base_class_keeps_tight_3channel_contract(self) -> None:
+        """ChannelSelectorBase keeps shape (-1,-1,-1,3) so the 11 sibling
+        selectors (FastRGBSelector, CIRSelector, NDVI variants, etc.) — all of
+        which emit exactly 3 channels — keep their pipeline-validation safety
+        net. Only FixedWavelengthSelector overrides this."""
         spec = ChannelSelectorBase.OUTPUT_SPECS["rgb_image"]
-        assert spec.shape == (-1, -1, -1, -1), (
-            f"Expected (-1,-1,-1,-1), got {spec.shape}. "
-            "This would reject n-channel output from FixedWavelengthSelector."
+        assert spec.shape == (-1, -1, -1, 3), (
+            f"Expected (-1,-1,-1,3), got {spec.shape}. Loosening the base class "
+            "would remove validation for every fixed-3-channel selector subclass."
         )
 
-    def test_fixed_selector_inherits_relaxed_spec(self) -> None:
-        sel = FixedWavelengthSelector(target_wavelengths=(650.0, 550.0, 450.0))
-        spec = sel.OUTPUT_SPECS["rgb_image"]
+    def test_fixed_selector_overrides_to_n_channel(self) -> None:
+        """FixedWavelengthSelector specifically overrides OUTPUT_SPECS to
+        (-1,-1,-1,-1) so it can emit an n-channel stack. The base class
+        is unaffected."""
+        spec = FixedWavelengthSelector.OUTPUT_SPECS["rgb_image"]
         assert spec.shape == (-1, -1, -1, -1)
+        # Verify base is independent of subclass override.
+        assert ChannelSelectorBase.OUTPUT_SPECS["rgb_image"].shape == (-1, -1, -1, 3)
+        # And the subclass spec dict still inherits the other ports from base.
+        assert "band_info" in FixedWavelengthSelector.OUTPUT_SPECS
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +132,9 @@ class TestNChannelOutput:
     def test_six_channel_output_shape(self) -> None:
         """6-target-wavelengths → output shape [B, H, W, 6]."""
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
-        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=False, norm_mode="per_frame"
+        )
         cube = _cube(B=2, H=8, W=8, C=20)
         wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
         out = sel.forward(cube, wl)
@@ -125,7 +142,9 @@ class TestNChannelOutput:
 
     def test_six_channel_dtype_is_float32(self) -> None:
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
-        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=False, norm_mode="per_frame"
+        )
         cube = _cube(C=20)
         wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
         out = sel.forward(cube, wl)
@@ -133,7 +152,9 @@ class TestNChannelOutput:
 
     def test_six_channel_band_info_length(self) -> None:
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
-        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=False, norm_mode="per_frame"
+        )
         cube = _cube(C=20)
         wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
         out = sel.forward(cube, wl)
@@ -144,7 +165,9 @@ class TestNChannelOutput:
         """Each output channel must be exactly the nearest cube band, not a mix."""
         wl = np.array([450.0, 550.0, 625.0, 1050.0, 1200.0, 1450.0], dtype=np.float32)
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
-        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=False, norm_mode="per_frame"
+        )
         # Cube: each channel c is filled with float(c) so we can identify which band landed where
         cube = torch.zeros(1, 4, 4, 6)
         for c in range(6):
@@ -160,7 +183,9 @@ class TestNChannelOutput:
 
     def test_single_channel_output_shape(self) -> None:
         """Single target wavelength → [B, H, W, 1]."""
-        sel = FixedWavelengthSelector(target_wavelengths=(550.0,), normalize_output=False)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(550.0,), normalize_output=False, norm_mode="per_frame"
+        )
         cube = _cube(C=10)
         wl = _wavelengths(10)
         out = sel.forward(cube, wl)
@@ -173,15 +198,50 @@ class TestNChannelOutput:
 
 
 class TestNormalizeOutputWarning:
-    def test_six_channel_normalize_true_warns_and_returns_raw(self) -> None:
-        """normalize_output=True with n=6 must warn and return raw stacked bands."""
+    def test_six_channel_normalize_true_warns_once_at_construction(self) -> None:
+        """normalize_output=True with n=6 must warn ONCE at __init__ (not per
+        forward call) and the forward must return raw stacked bands.
+
+        Regression for review point 4: previously the warning was emitted from
+        inside forward(), which in a video run is one identical warning per
+        frame. The fix hoists it to __init__ where n and normalize_output are
+        both known and don't change later.
+        """
+        from loguru import logger
 
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
-        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=True)
-        cube = _cube(C=20) * 500.0  # large values to show normalization was NOT applied
+        warnings_seen: list[str] = []
+        sink_id = logger.add(lambda m: warnings_seen.append(m.record["message"]), level="WARNING")
+        try:
+            sel = FixedWavelengthSelector(
+                target_wavelengths=targets, normalize_output=True, norm_mode="per_frame"
+            )
+            warns_after_init = len(warnings_seen)
+            # Multiple forward calls must NOT add new warnings.
+            cube = _cube(C=20) * 500.0
+            wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+            for _ in range(5):
+                sel.forward(cube, wl)
+            warns_after_forwards = len(warnings_seen)
+        finally:
+            logger.remove(sink_id)
+
+        assert warns_after_init == 1, (
+            f"Expected exactly 1 warning at __init__, got {warns_after_init}"
+        )
+        assert "normalize_output=True is only supported" in warnings_seen[0]
+        assert warns_after_forwards == 1, (
+            f"forward() must not emit further warnings; got {warns_after_forwards} total."
+        )
+
+    def test_six_channel_normalize_true_returns_raw(self) -> None:
+        """Forward returns raw stacked bands (not normalised) for n != 3."""
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=True, norm_mode="per_frame"
+        )
+        cube = _cube(C=20) * 500.0  # large values so normalisation would crush them
         wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
-        # loguru warnings don't go through warnings.warn, so just check the output
-        # shape is correct and values are > 1 (proving no normalization happened).
         out = sel.forward(cube, wl)
         assert out["rgb_image"].shape == (1, 4, 4, 6)
         # Raw cube values are ~0-500, so at least some pixels should be > 1
@@ -191,12 +251,126 @@ class TestNormalizeOutputWarning:
 
     def test_four_channel_normalize_true_returns_raw(self) -> None:
         sel = FixedWavelengthSelector(
-            target_wavelengths=(700.0, 600.0, 500.0, 400.0), normalize_output=True
+            target_wavelengths=(700.0, 600.0, 500.0, 400.0),
+            normalize_output=True,
+            norm_mode="per_frame",
         )
         cube = _cube(C=10) * 200.0
         wl = _wavelengths(10)
         out = sel.forward(cube, wl)
         assert out["rgb_image"].shape == (1, 4, 4, 4)
+
+    def test_three_channel_normalize_false_does_not_warn(self) -> None:
+        """normalize_output=False on the standard 3-channel default must NOT
+        trigger the n != 3 warning."""
+        from loguru import logger
+
+        warnings_seen: list[str] = []
+        sink_id = logger.add(lambda m: warnings_seen.append(m.record["message"]), level="WARNING")
+        try:
+            FixedWavelengthSelector(
+                target_wavelengths=(650.0, 550.0, 450.0),
+                normalize_output=False,
+                norm_mode="per_frame",
+            )
+        finally:
+            logger.remove(sink_id)
+        relevant = [w for w in warnings_seen if "normalize_output" in w]
+        assert relevant == [], (
+            f"Unexpected warning(s) at __init__ for the 3-channel default: {relevant}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# norm_mode guard (review point 1) — running/statistical require n == 3
+# ---------------------------------------------------------------------------
+
+
+class TestNormModeGuard:
+    """The running/statistical normalisation paths in ChannelSelectorBase rely
+    on 3-element buffers and ``reshape(-1, 3)`` of the raw RGB tensor. For
+    ``n != 3`` they would silently mix unrelated channels (e.g. n=6 reshapes
+    the 6-channel pixels into pairs of c0+c3, c1+c4, c2+c5 per row) or raise a
+    ``RuntimeError`` on non-divisible totals (n=4). Reject these modes at
+    construction so the failure mode is loud and obvious."""
+
+    @pytest.mark.parametrize("mode", ["statistical", "running"])
+    def test_n6_with_unsupported_mode_raises(self, mode: str) -> None:
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        with pytest.raises(ValueError, match="norm_mode.*requires exactly 3"):
+            FixedWavelengthSelector(target_wavelengths=targets, norm_mode=mode)
+
+    @pytest.mark.parametrize("mode", ["statistical", "running"])
+    def test_n4_with_unsupported_mode_raises(self, mode: str) -> None:
+        with pytest.raises(ValueError, match="norm_mode.*requires exactly 3"):
+            FixedWavelengthSelector(target_wavelengths=(700.0, 600.0, 500.0, 400.0), norm_mode=mode)
+
+    @pytest.mark.parametrize("mode", ["statistical", "running"])
+    def test_n3_with_either_mode_is_allowed(self, mode: str) -> None:
+        """3-channel selectors with running/statistical mode must still
+        construct cleanly — that's the original supported configuration."""
+        sel = FixedWavelengthSelector(target_wavelengths=(650.0, 550.0, 450.0), norm_mode=mode)
+        assert sel.norm_mode.value == mode
+
+    @pytest.mark.parametrize("n", [1, 4, 6, 9])
+    def test_n_neq_3_with_per_frame_is_allowed(self, n: int) -> None:
+        """per_frame is the only mode supported for n != 3 today."""
+        targets = tuple(450.0 + 100.0 * i for i in range(n))
+        sel = FixedWavelengthSelector(target_wavelengths=targets, norm_mode="per_frame")
+        assert len(sel.target_wavelengths) == n
+
+
+# ---------------------------------------------------------------------------
+# band_info honesty (review point 2) + strategy label (review point 8)
+# ---------------------------------------------------------------------------
+
+
+class TestBandInfoHonesty:
+    def test_band_info_normalized_output_false_when_n_neq_3(self) -> None:
+        """band_info['normalized_output'] must reflect what actually happened.
+        For n != 3 the forward returns raw bands, so the flag must be False
+        even if the user passed normalize_output=True at construction.
+
+        Regression for review point 2: previously the flag mirrored the input
+        kwarg, so a consumer that trusted the flag would skip a normalisation
+        it still needed."""
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=targets, normalize_output=True, norm_mode="per_frame"
+        )
+        cube = _cube(C=20)
+        wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+        out = sel.forward(cube, wl)
+        assert out["band_info"]["normalized_output"] is False, (
+            "n != 3 returns raw bands, so band_info['normalized_output'] must be False"
+        )
+
+    def test_band_info_normalized_output_true_when_n3_and_normalized(self) -> None:
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(650.0, 550.0, 450.0),
+            normalize_output=True,
+            norm_mode="per_frame",
+        )
+        cube = _cube(C=10) * 500.0
+        out = sel.forward(cube, _wavelengths(10))
+        assert out["band_info"]["normalized_output"] is True
+
+    def test_band_info_strategy_label_branches_on_n(self) -> None:
+        """Review point 8: ``band_info['strategy']`` was hard-coded
+        ``baseline_false_rgb`` even for 6-channel output. Now it branches:
+        ``baseline_false_rgb`` for n == 3, ``stacked_bands`` otherwise."""
+        sel3 = FixedWavelengthSelector(
+            target_wavelengths=(650.0, 550.0, 450.0), normalize_output=False
+        )
+        sel6 = FixedWavelengthSelector(
+            target_wavelengths=(625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0),
+            normalize_output=False,
+            norm_mode="per_frame",
+        )
+        wl = _wavelengths(20, lo=400.0, hi=1500.0)
+        cube = _cube(C=20)
+        assert sel3.forward(cube, wl)["band_info"]["strategy"] == "baseline_false_rgb"
+        assert sel6.forward(cube, wl)["band_info"]["strategy"] == "stacked_bands"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/node/test_fixed_wavelength_selector.py
+++ b/tests/node/test_fixed_wavelength_selector.py
@@ -1,0 +1,214 @@
+"""Tests for FixedWavelengthSelector generalization to n-channel output.
+
+Covers:
+- Backward compat: 3-channel default still works exactly as before
+- n-channel (e.g. 6) band stacking — shape, dtype, correct band pick
+- Empty / single wavelength edge cases
+- normalize_output=True warning for n != 3
+- OUTPUT_SPECS shape relaxed to (-1,-1,-1,-1)
+- ChannelSelectorBase OUTPUT_SPECS shape is (-1,-1,-1,-1)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from cuvis_ai.node.channel_selector import ChannelSelectorBase, FixedWavelengthSelector
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _cube(B: int = 1, H: int = 4, W: int = 4, C: int = 10) -> torch.Tensor:
+    return torch.rand(B, H, W, C)
+
+
+def _wavelengths(n: int = 10, lo: float = 400.0, hi: float = 900.0) -> np.ndarray:
+    return np.linspace(lo, hi, n, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# OUTPUT_SPECS shape relaxation
+# ---------------------------------------------------------------------------
+
+class TestOutputSpecsShape:
+    def test_base_class_output_spec_is_n_channel(self) -> None:
+        """ChannelSelectorBase.OUTPUT_SPECS must have shape (-1,-1,-1,-1), not (-1,-1,-1,3)."""
+        spec = ChannelSelectorBase.OUTPUT_SPECS["rgb_image"]
+        assert spec.shape == (-1, -1, -1, -1), (
+            f"Expected (-1,-1,-1,-1), got {spec.shape}. "
+            "This would reject n-channel output from FixedWavelengthSelector."
+        )
+
+    def test_fixed_selector_inherits_relaxed_spec(self) -> None:
+        sel = FixedWavelengthSelector(target_wavelengths=(650.0, 550.0, 450.0))
+        spec = sel.OUTPUT_SPECS["rgb_image"]
+        assert spec.shape == (-1, -1, -1, -1)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — 3-channel default
+# ---------------------------------------------------------------------------
+
+class TestThreeChannelBackwardCompat:
+    def test_default_wavelengths_output_shape(self) -> None:
+        """Default (650, 550, 450) must still produce [B, H, W, 3]."""
+        sel = FixedWavelengthSelector(normalize_output=False)
+        cube = _cube(C=10)
+        wl = _wavelengths(10)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (1, 4, 4, 3)
+
+    def test_three_channel_with_normalize_uses_compose_rgb(self) -> None:
+        """normalize_output=True + 3 channels → _compose_rgb is called → 0-1 range."""
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(650.0, 550.0, 450.0),
+            normalize_output=True,
+            norm_mode="per_frame",
+        )
+        # Use a cube with known max so output lands in [0,1]
+        cube = torch.rand(1, 4, 4, 10) * 500.0
+        wl = _wavelengths(10)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (1, 4, 4, 3)
+        assert out["rgb_image"].dtype == torch.float32
+        assert float(out["rgb_image"].max()) <= 1.0 + 1e-5
+
+    def test_band_info_strategy_and_fields(self) -> None:
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(650.0, 550.0, 450.0), normalize_output=False
+        )
+        cube = _cube(C=10)
+        wl = _wavelengths(10)
+        out = sel.forward(cube, wl)
+        info = out["band_info"]
+        assert info["strategy"] == "baseline_false_rgb"
+        assert len(info["band_indices"]) == 3
+        assert len(info["band_wavelengths_nm"]) == 3
+        assert info["target_wavelengths_nm"] == [650.0, 550.0, 450.0]
+        assert info["normalized_output"] is False
+
+    def test_picks_nearest_band(self) -> None:
+        """The selected band index should be the one closest to each target."""
+        wl = np.array([400.0, 500.0, 600.0, 700.0], dtype=np.float32)
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(610.0, 490.0, 410.0), normalize_output=False
+        )
+        cube = _cube(C=4)
+        out = sel.forward(cube, wl)
+        # 610 → nearest is 600 (index 2), 490 → 500 (index 1), 410 → 400 (index 0)
+        assert out["band_info"]["band_indices"] == [2, 1, 0]
+
+
+# ---------------------------------------------------------------------------
+# n-channel generalization
+# ---------------------------------------------------------------------------
+
+class TestNChannelOutput:
+    def test_six_channel_output_shape(self) -> None:
+        """6-target-wavelengths → output shape [B, H, W, 6]."""
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        cube = _cube(B=2, H=8, W=8, C=20)
+        wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (2, 8, 8, 6)
+
+    def test_six_channel_dtype_is_float32(self) -> None:
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        cube = _cube(C=20)
+        wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].dtype == torch.float32
+
+    def test_six_channel_band_info_length(self) -> None:
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        cube = _cube(C=20)
+        wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+        out = sel.forward(cube, wl)
+        assert len(out["band_info"]["band_indices"]) == 6
+        assert len(out["band_info"]["band_wavelengths_nm"]) == 6
+
+    def test_six_channel_values_match_cube_bands(self) -> None:
+        """Each output channel must be exactly the nearest cube band, not a mix."""
+        wl = np.array([450.0, 550.0, 625.0, 1050.0, 1200.0, 1450.0], dtype=np.float32)
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=False)
+        # Cube: each channel c is filled with float(c) so we can identify which band landed where
+        cube = torch.zeros(1, 4, 4, 6)
+        for c in range(6):
+            cube[..., c] = float(c)
+        out = sel.forward(cube, wl)
+        rgb = out["rgb_image"]  # [1, 4, 4, 6]
+        # target order: 625→idx2, 550→idx1, 450→idx0, 1450→idx5, 1200→idx4, 1050→idx3
+        expected_values = [2.0, 1.0, 0.0, 5.0, 4.0, 3.0]
+        for ch, expected in enumerate(expected_values):
+            assert float(rgb[0, 0, 0, ch]) == pytest.approx(expected), (
+                f"channel {ch}: expected {expected}, got {float(rgb[0, 0, 0, ch])}"
+            )
+
+    def test_single_channel_output_shape(self) -> None:
+        """Single target wavelength → [B, H, W, 1]."""
+        sel = FixedWavelengthSelector(target_wavelengths=(550.0,), normalize_output=False)
+        cube = _cube(C=10)
+        wl = _wavelengths(10)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (1, 4, 4, 1)
+
+
+# ---------------------------------------------------------------------------
+# normalize_output=True warning for n != 3
+# ---------------------------------------------------------------------------
+
+class TestNormalizeOutputWarning:
+    def test_six_channel_normalize_true_warns_and_returns_raw(self) -> None:
+        """normalize_output=True with n=6 must warn and return raw stacked bands."""
+        import warnings
+        targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
+        sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=True)
+        cube = _cube(C=20) * 500.0  # large values to show normalization was NOT applied
+        wl = np.linspace(400.0, 1500.0, 20, dtype=np.float32)
+        # loguru warnings don't go through warnings.warn, so just check the output
+        # shape is correct and values are > 1 (proving no normalization happened).
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (1, 4, 4, 6)
+        # Raw cube values are ~0-500, so at least some pixels should be > 1
+        assert float(out["rgb_image"].max()) > 1.0, (
+            "Expected raw (unnormalized) values > 1 for n=6 with normalize_output=True"
+        )
+
+    def test_four_channel_normalize_true_returns_raw(self) -> None:
+        sel = FixedWavelengthSelector(
+            target_wavelengths=(700.0, 600.0, 500.0, 400.0), normalize_output=True
+        )
+        cube = _cube(C=10) * 200.0
+        wl = _wavelengths(10)
+        out = sel.forward(cube, wl)
+        assert out["rgb_image"].shape == (1, 4, 4, 4)
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+class TestConstructorValidation:
+    def test_empty_wavelengths_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one wavelength"):
+            FixedWavelengthSelector(target_wavelengths=())
+
+    def test_string_wavelengths_rejected_by_tuple_coercion(self) -> None:
+        """Non-numeric strings should raise during float coercion."""
+        with pytest.raises((ValueError, TypeError)):
+            FixedWavelengthSelector(target_wavelengths=("red", "green", "blue"))
+
+    def test_wavelengths_coerced_to_float(self) -> None:
+        """Integer wavelengths should be accepted and stored as float."""
+        sel = FixedWavelengthSelector(target_wavelengths=(650, 550, 450))
+        assert all(isinstance(w, float) for w in sel.target_wavelengths)

--- a/tests/node/test_fixed_wavelength_selector.py
+++ b/tests/node/test_fixed_wavelength_selector.py
@@ -175,7 +175,6 @@ class TestNChannelOutput:
 class TestNormalizeOutputWarning:
     def test_six_channel_normalize_true_warns_and_returns_raw(self) -> None:
         """normalize_output=True with n=6 must warn and return raw stacked bands."""
-        import warnings
 
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
         sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=True)

--- a/tests/node/test_fixed_wavelength_selector.py
+++ b/tests/node/test_fixed_wavelength_selector.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.unit
 # Helper
 # ---------------------------------------------------------------------------
 
+
 def _cube(B: int = 1, H: int = 4, W: int = 4, C: int = 10) -> torch.Tensor:
     return torch.rand(B, H, W, C)
 
@@ -35,6 +36,7 @@ def _wavelengths(n: int = 10, lo: float = 400.0, hi: float = 900.0) -> np.ndarra
 # ---------------------------------------------------------------------------
 # OUTPUT_SPECS shape relaxation
 # ---------------------------------------------------------------------------
+
 
 class TestOutputSpecsShape:
     def test_base_class_output_spec_is_n_channel(self) -> None:
@@ -54,6 +56,7 @@ class TestOutputSpecsShape:
 # ---------------------------------------------------------------------------
 # Backward compatibility — 3-channel default
 # ---------------------------------------------------------------------------
+
 
 class TestThreeChannelBackwardCompat:
     def test_default_wavelengths_output_shape(self) -> None:
@@ -108,6 +111,7 @@ class TestThreeChannelBackwardCompat:
 # ---------------------------------------------------------------------------
 # n-channel generalization
 # ---------------------------------------------------------------------------
+
 
 class TestNChannelOutput:
     def test_six_channel_output_shape(self) -> None:
@@ -167,10 +171,12 @@ class TestNChannelOutput:
 # normalize_output=True warning for n != 3
 # ---------------------------------------------------------------------------
 
+
 class TestNormalizeOutputWarning:
     def test_six_channel_normalize_true_warns_and_returns_raw(self) -> None:
         """normalize_output=True with n=6 must warn and return raw stacked bands."""
         import warnings
+
         targets = (625.0, 550.0, 450.0, 1450.0, 1200.0, 1050.0)
         sel = FixedWavelengthSelector(target_wavelengths=targets, normalize_output=True)
         cube = _cube(C=20) * 500.0  # large values to show normalization was NOT applied
@@ -197,6 +203,7 @@ class TestNormalizeOutputWarning:
 # ---------------------------------------------------------------------------
 # Constructor validation
 # ---------------------------------------------------------------------------
+
 
 class TestConstructorValidation:
     def test_empty_wavelengths_raises(self) -> None:

--- a/tests/node/test_percentile_normalizer.py
+++ b/tests/node/test_percentile_normalizer.py
@@ -1,0 +1,219 @@
+"""Tests for PercentileNormalizer (per-channel n-channel normalization).
+
+Covers constructor validation, the three modes, channel-count guarding, the
+statistical fit path, frame-count persistence across a state_dict round-trip, and
+the critical bit-for-bit parity with the normalization machinery still living in
+``ChannelSelectorBase`` (the safety net for the later selector migration).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cuvis_ai.node.channel_selector import ChannelSelectorBase
+from cuvis_ai.node.normalization import DisplayNormalizer, PercentileNormalizer
+
+pytestmark = pytest.mark.unit
+
+
+class _RefSelector(ChannelSelectorBase):
+    """Minimal concrete selector exposing the base normalization helpers.
+
+    ``ChannelSelectorBase.forward`` is abstract; the parity tests only call the
+    inherited normalization helpers (``_per_frame_normalize``,
+    ``_running_normalize``, ``_apply_accumulated_stats``, ``_normalize_rgb``), so
+    this stub just satisfies the abstract method.
+    """
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - unused in parity tests
+        raise NotImplementedError
+
+
+def _raw(B: int = 1, H: int = 4, W: int = 4, C: int = 3, scale: float = 500.0) -> torch.Tensor:
+    """Deterministic raw (unnormalized) BHWC radiance-like tensor."""
+    g = torch.Generator().manual_seed(1234 + C)
+    return torch.rand(B, H, W, C, generator=g) * scale
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorValidation:
+    @pytest.mark.parametrize("n", [0, -1])
+    def test_non_positive_n_channels_raises(self, n: int) -> None:
+        with pytest.raises(ValueError, match="n_channels"):
+            PercentileNormalizer(n_channels=n)
+
+    def test_bool_n_channels_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_channels"):
+            PercentileNormalizer(n_channels=True)  # type: ignore[arg-type]
+
+    def test_invalid_norm_mode_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PercentileNormalizer(n_channels=3, norm_mode="bogus")
+
+    def test_bad_quantiles_raise(self) -> None:
+        with pytest.raises(ValueError, match="quantile"):
+            PercentileNormalizer(n_channels=3, quantile_low=0.9, quantile_high=0.1)
+
+    def test_bad_warmup_raises(self) -> None:
+        with pytest.raises(ValueError, match="running_warmup_frames"):
+            PercentileNormalizer(n_channels=3, running_warmup_frames=-1)
+
+    def test_only_statistical_requires_fit(self) -> None:
+        assert PercentileNormalizer(n_channels=3, norm_mode="statistical").requires_initial_fit
+        assert not PercentileNormalizer(n_channels=3, norm_mode="running").requires_initial_fit
+        assert not PercentileNormalizer(n_channels=3, norm_mode="per_frame").requires_initial_fit
+
+
+# ---------------------------------------------------------------------------
+# Channel handling
+# ---------------------------------------------------------------------------
+
+
+class TestChannels:
+    def test_channel_mismatch_raises(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="per_frame")
+        with pytest.raises(ValueError, match="expected 3 channels"):
+            node.forward(data=_raw(C=6))
+
+    @pytest.mark.parametrize("c", [1, 4, 6, 9])
+    def test_n_channel_output_shape_and_range(self, c: int) -> None:
+        node = PercentileNormalizer(n_channels=c, norm_mode="per_frame")
+        out = node.forward(data=_raw(B=2, H=8, W=8, C=c))["normalized"]
+        assert out.shape == (2, 8, 8, c)
+        assert out.dtype == torch.float32
+        assert float(out.min()) >= -1e-6
+        assert float(out.max()) <= 1.0 + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Statistical mode
+# ---------------------------------------------------------------------------
+
+
+class TestStatistical:
+    def test_forward_before_fit_raises(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="statistical")
+        with pytest.raises(RuntimeError, match="statistical_initialization"):
+            node.forward(data=_raw())
+
+    def test_empty_stream_raises(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="statistical")
+        with pytest.raises(RuntimeError, match="received no data"):
+            node.statistical_initialization(iter([]))
+
+    def test_fit_then_apply_in_range(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="statistical")
+        batches = [{"data": _raw(scale=300.0)}, {"data": _raw(scale=900.0)}]
+        node.statistical_initialization(iter(batches))
+        assert not torch.isnan(node.running_min).any()
+        out = node.forward(data=_raw(scale=600.0))["normalized"]
+        assert float(out.min()) >= -1e-6 and float(out.max()) <= 1.0 + 1e-6
+
+    def test_fit_accumulates_min_of_lows_max_of_highs(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="statistical")
+        b1, b2 = _raw(scale=100.0), _raw(scale=1000.0)
+        node.statistical_initialization(iter([{"data": b1}, {"data": b2}]))
+        f1l = torch.quantile(b1.reshape(-1, 3).float(), 0.005, dim=0)
+        f2l = torch.quantile(b2.reshape(-1, 3).float(), 0.005, dim=0)
+        f1h = torch.quantile(b1.reshape(-1, 3).float(), 0.995, dim=0)
+        f2h = torch.quantile(b2.reshape(-1, 3).float(), 0.995, dim=0)
+        assert torch.allclose(node.running_min, torch.minimum(f1l, f2l))
+        assert torch.allclose(node.running_max, torch.maximum(f1h, f2h))
+
+
+# ---------------------------------------------------------------------------
+# Frame-count + bounds persistence (state_dict round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_frame_count_and_bounds_survive_state_dict(self) -> None:
+        node = PercentileNormalizer(n_channels=3, norm_mode="running", running_warmup_frames=2)
+        for _ in range(5):
+            node.forward(data=_raw())
+        assert int(node._norm_frame_count.item()) == 5
+
+        restored = PercentileNormalizer(n_channels=3, norm_mode="running", running_warmup_frames=2)
+        restored.load_state_dict(node.state_dict())
+        assert int(restored._norm_frame_count.item()) == 5
+        assert torch.allclose(restored.running_min, node.running_min)
+        assert torch.allclose(restored.running_max, node.running_max)
+
+    def test_freeze_stops_updating_bounds(self) -> None:
+        node = PercentileNormalizer(
+            n_channels=3,
+            norm_mode="running",
+            running_warmup_frames=0,
+            freeze_running_bounds_after_frames=2,
+        )
+        node.forward(data=_raw(scale=100.0))
+        node.forward(data=_raw(scale=100.0))
+        frozen_min = node.running_min.clone()
+        frozen_max = node.running_max.clone()
+        # A much wider frame after freeze must not move the bounds.
+        node.forward(data=_raw(scale=5000.0))
+        assert torch.allclose(node.running_min, frozen_min)
+        assert torch.allclose(node.running_max, frozen_max)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL parity with ChannelSelectorBase (the migration safety net)
+# ---------------------------------------------------------------------------
+
+
+class TestParityWithSelector:
+    """PercentileNormalizer(n_channels=3) must reproduce the selector's
+    normalization bit-for-bit, per mode. This proves the later selector
+    migration is behaviour-preserving."""
+
+    def test_per_frame_parity(self) -> None:
+        raw = _raw(B=2, C=3)
+        norm = PercentileNormalizer(n_channels=3, norm_mode="per_frame")
+        ref = _RefSelector(norm_mode="per_frame")
+        assert torch.allclose(norm.forward(data=raw)["normalized"], ref._per_frame_normalize(raw))
+
+    def test_running_parity_across_frames(self) -> None:
+        norm = PercentileNormalizer(n_channels=3, norm_mode="running")
+        ref = _RefSelector(norm_mode="running")
+        for i in range(15):  # spans warmup (10) and post-warmup accumulation
+            raw = _raw(B=1, C=3, scale=200.0 + 50.0 * i)
+            got = norm.forward(data=raw)["normalized"]
+            want = ref._running_normalize(raw)
+            assert torch.allclose(got, want), f"frame {i} diverged"
+
+    def test_statistical_apply_parity(self) -> None:
+        norm = PercentileNormalizer(n_channels=3, norm_mode="statistical")
+        ref = _RefSelector(norm_mode="statistical")
+        lo = torch.tensor([1.0, 2.0, 3.0])
+        hi = torch.tensor([10.0, 20.0, 30.0])
+        for n in (norm, ref):
+            n.running_min.copy_(lo)
+            n.running_max.copy_(hi)
+        norm._statistically_initialized = True  # mirror ref state flag if present
+        ref._statistically_initialized = True
+        raw = _raw(C=3)
+        assert torch.allclose(
+            norm.forward(data=raw)["normalized"], ref._apply_accumulated_stats(raw)
+        )
+
+    @pytest.mark.parametrize("mode", ["per_frame", "running", "statistical"])
+    def test_chain_with_display_matches_selector_with_gamma(self, mode: str) -> None:
+        """selector(apply_gamma=True) == PercentileNormalizer -> DisplayNormalizer."""
+        raw = _raw(C=3)
+        norm = PercentileNormalizer(n_channels=3, norm_mode=mode)
+        display = DisplayNormalizer()
+        ref = _RefSelector(norm_mode=mode, apply_gamma=True)
+        if mode == "statistical":
+            lo, hi = torch.tensor([1.0, 2.0, 3.0]), torch.tensor([10.0, 20.0, 30.0])
+            for n in (norm, ref):
+                n.running_min.copy_(lo)
+                n.running_max.copy_(hi)
+            norm._statistically_initialized = True
+            ref._statistically_initialized = True
+        chained = display.forward(data=norm.forward(data=raw)["normalized"])["normalized"]
+        assert torch.allclose(chained, ref._normalize_rgb(raw))


### PR DESCRIPTION
## Summary

- Relaxes `ChannelSelectorBase.OUTPUT_SPECS["rgb_image"].shape` from `(-1,-1,-1,3)` to `(-1,-1,-1,-1)` so the port-spec validator accepts any channel count
- Generalizes `FixedWavelengthSelector.target_wavelengths` type annotation from `tuple[float, float, float]` to `tuple[float, ...]` with `len >= 1` validation
- Gates `_compose_rgb` (running bounds + gamma normalization) behind `normalize_output=True AND n==3`; for `n != 3` bands are stacked raw with a warning if `normalize_output=True`

**Fully backward compatible** — existing 3-channel callers are unaffected (verified by tests).

## Motivation

The `cuvis-ai-dinomaly` plugin needed a 6-channel band selector (VIS 625/550/450 nm + SWIR 1450/1200/1050 nm) for the bedding anomaly detection pilot. The upstream `FixedWavelengthSelector` rejected n≠3 output at the port-spec layer (`shape=(-1,-1,-1,3)`), forcing a plugin-local workaround (`FixedHyperspectralSelector`). This change removes the need for that workaround.

Closes: ALL-5779

## Test plan

- `tests/node/test_fixed_wavelength_selector.py` (16 new tests):
  - [ ] OUTPUT_SPECS shape is `(-1,-1,-1,-1)` on base class and selector
  - [ ] 3-channel default: shape, normalize path, band_info fields, nearest-band pick
  - [ ] 6-channel: shape `[B,H,W,6]`, dtype, band_info length, exact band values
  - [ ] Single-channel: shape `[B,H,W,1]`
  - [ ] `normalize_output=True` warning + raw fallback for n≠3
  - [ ] Constructor: empty tuple raises, bad type raises, int→float coercion
- 788 existing tests pass (`uv run pytest tests/ -q --ignore=tests/training --ignore=tests/anomaly`)