### PR TITLE
ci: scope detect-secrets scan to git-tracked files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run detect-secrets
         run: |
-          uv run detect-secrets scan --all-files \
+          uv run detect-secrets scan \
             --exclude-files '\.lock$|\.egg-info|\.pyc$|site/|\.git/|\.pytest_cache' \
             --baseline .secrets.baseline
 


### PR DESCRIPTION
Drop `--all-files` so detect-secrets scans only git-tracked files (its default) instead of the synced `.venv`. Cuts the Security Scanning job from ~15 min to seconds; same coverage of committed source. Brings cuvis-ai in line with the plugin repos that already scan tracked-only.