### PR TITLE
feat(plugins): refresh manifest pins, register augment, add pin auto-bump CI

### DIFF
--- a/.github/workflows/no-local-sources.yml
+++ b/.github/workflows/no-local-sources.yml
@@ -1,0 +1,40 @@
+name: No Local Sources
+
+# Fails CI if pyproject.toml declares a local [tool.uv.sources] path entry. A machine-specific
+# editable path must never ship in a release: it breaks a fresh `uv sync` / install of the tag.
+# Commented-out path entries are fine -- tomllib never sees them.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  no-local-sources:
+    name: Reject local uv.sources paths
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check pyproject.toml
+        run: |
+          python - <<'PY'
+          import pathlib, tomllib
+          pp = pathlib.Path("pyproject.toml")
+          if not pp.exists():
+              print("no pyproject.toml; nothing to check")
+              raise SystemExit(0)
+          sources = tomllib.load(pp.open("rb")).get("tool", {}).get("uv", {}).get("sources", {})
+          local = {k: v for k, v in sources.items() if isinstance(v, dict) and "path" in v}
+          if local:
+              print("ERROR: local [tool.uv.sources] path entries must not be committed:")
+              for name, spec in local.items():
+                  print(f"  {name} = {spec}")
+              raise SystemExit(1)
+          print("OK: no local path sources in [tool.uv.sources]")
+          PY

--- a/.github/workflows/plugin_pin_bump.yml
+++ b/.github/workflows/plugin_pin_bump.yml
@@ -1,7 +1,8 @@
 name: Plugin Pin Bump
 
 # Opens (or updates) a PR that bumps each configs/plugins/*.yaml tag pin to the plugin's
-# latest GitHub release, so the catalog tracks plugin releases without manual edits.
+# latest GitHub release, so the catalog tracks plugin releases without manual edits. The bump is
+# tag-only; if a release changed its node set the PR is flagged for a manual capabilities regen.
 #
 # Runs weekly and on demand. A PR opened with the default GITHUB_TOKEN does NOT trigger
 # this repo's CI on that PR, so the bot must authenticate as a GitHub App. The job is
@@ -46,12 +47,17 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Bump stale pins
+        id: bump
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: >
           uv run --no-project --python 3.11 --with pyyaml
           python scripts/bump_plugin_pins.py | tee bump.log
 
+      # On capability drift the bump script sets `drift=true`; flag the PR via title and (if the
+      # `needs-capabilities-review` label exists) a label, so the stale capabilities block gets a
+      # manual regen. Applying an existing label needs only pull_requests:write; creating the label
+      # would need issues:write, which the App lacks, so the label must pre-exist in the repo.
       - name: Open / update the bump PR
         uses: peter-evans/create-pull-request@v7
         with:
@@ -59,7 +65,11 @@ jobs:
           branch: bot/bump-plugin-pins
           delete-branch: true
           commit-message: "chore(plugins): bump plugin manifest pins to latest releases"
-          title: "chore(plugins): bump plugin manifest pins"
+          title: >-
+            ${{ steps.bump.outputs.drift == 'true'
+            && 'chore(plugins): bump plugin manifest pins (CAPABILITIES REVIEW NEEDED)'
+            || 'chore(plugins): bump plugin manifest pins' }}
+          labels: ${{ steps.bump.outputs.drift == 'true' && 'needs-capabilities-review' || '' }}
           body-path: bump.log
           add-paths: |
             configs/plugins/*.yaml

--- a/.github/workflows/plugin_pin_bump.yml
+++ b/.github/workflows/plugin_pin_bump.yml
@@ -1,0 +1,66 @@
+name: Plugin Pin Bump
+
+# Opens (or updates) a PR that bumps each configs/plugins/*.yaml tag pin to the plugin's
+# latest GitHub release, so the catalog tracks plugin releases without manual edits.
+#
+# Runs weekly and on demand. A PR opened with the default GITHUB_TOKEN does NOT trigger
+# this repo's CI on that PR, so the bot must authenticate as a GitHub App. The job is
+# guarded on the App id being configured: until the `PIN_BUMP_APP_ID` repo variable and
+# `PIN_BUMP_APP_PRIVATE_KEY` secret exist, it is skipped (never red). When no plugin has a
+# newer release, the script no-ops and no PR is opened.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: plugin-pin-bump
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump plugin manifest pins
+    runs-on: ubuntu-latest
+    if: vars.PIN_BUMP_APP_ID != ''
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Generate a token for the bump PR
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.PIN_BUMP_APP_ID }}
+          private-key: ${{ secrets.PIN_BUMP_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Bump stale pins
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: >
+          uv run --no-project --python 3.11 --with pyyaml
+          python scripts/bump_plugin_pins.py | tee bump.log
+
+      - name: Open / update the bump PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: bot/bump-plugin-pins
+          delete-branch: true
+          commit-message: "chore(plugins): bump plugin manifest pins to latest releases"
+          title: "chore(plugins): bump plugin manifest pins"
+          body-path: bump.log
+          add-paths: |
+            configs/plugins/*.yaml
+            CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.11.0 - 2026-06-24
+
+- **Refreshed plugin manifest pins to the latest releases.** Bumped the `configs/plugins/` tags to
+  the published standards-adoption releases: adaclip `v0.1.5`, dinomaly `v0.2.0`, deepeiou `v0.2.0`,
+  trackeval `v0.1.3`, ultralytics `v0.1.3`, and the `cuvis_ai_dataloader` data-module plugin
+  `v0.2.0`. These are tag-only bumps; the releases carried no node or port changes, so each
+  manifest's `capabilities:` block is unchanged.
+- **Pinned sam3 to its first co-installable release.** `configs/plugins/sam3.yaml` swaps from the
+  local dev `path:` to `repo:` + `tag: v0.1.7`; v0.1.7 relaxes `setuptools<83`, resolving the
+  `setuptools>=81` conflict that had forced the local checkout.
+- **Registered the augment plugin.** Added `configs/plugins/augment.yaml` (capabilities format,
+  `tag: v0.3.0`) exposing `AugmentationCompose` for training-time cube/mask augmentation, plus a
+  manifest-sync test.
+- **Added a plugin-pin auto-bump workflow.** `.github/workflows/plugin_pin_bump.yml` +
+  `scripts/bump_plugin_pins.py` open a PR whenever a pinned plugin publishes a newer release. The
+  per-plugin manifest-sync tests now assert the pinned tag's *shape* (a well-formed `vX.Y.Z`)
+  instead of a frozen value, so a refresh only touches YAML. Also fixed
+  `scripts/fetch_plugin_pyprojects.py` to read the one-file manifest format (it had silently skipped
+  every manifest in the registry-compat audit).
+
 ## 0.10.0 - 2026-06-24
 
 - **`FixedWavelengthSelector` generalized to n-channel output.** `OUTPUT_SPECS["rgb_image"]` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@
   manifest-sync test.
 - **Added a plugin-pin auto-bump workflow.** `.github/workflows/plugin_pin_bump.yml` +
   `scripts/bump_plugin_pins.py` open a PR whenever a pinned plugin publishes a newer release. The
-  per-plugin manifest-sync tests now assert the pinned tag's *shape* (a well-formed `vX.Y.Z`)
-  instead of a frozen value, so a refresh only touches YAML. Also fixed
+  bump is tag-only, so it also compares the plugin's declared node set at the new tag against the
+  manifest's `capabilities` and flags the PR (title + `needs-capabilities-review` label) when the
+  release declares a node the manifest is missing (or the node set can't be verified), prompting a
+  manual capabilities regen. The per-plugin
+  manifest-sync tests now assert the pinned tag's *shape* (a well-formed `vX.Y.Z`) instead of a
+  frozen value, so a routine refresh only touches YAML. Also fixed
   `scripts/fetch_plugin_pyprojects.py` to read the one-file manifest format (it had silently skipped
   every manifest in the registry-compat audit).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@
   local dev `path:` to `repo:` + `tag: v0.1.7`; v0.1.7 relaxes `setuptools<83`, resolving the
   `setuptools>=81` conflict that had forced the local checkout.
 - **Registered the augment plugin.** Added `configs/plugins/augment.yaml` (capabilities format,
-  `tag: v0.3.0`) exposing `AugmentationCompose` for training-time cube/mask augmentation, plus a
+  `tag: v0.3.1`) exposing `AugmentationCompose` for training-time cube/mask augmentation, plus a
   manifest-sync test.
+- **Added a no-local-sources CI gate.** `.github/workflows/no-local-sources.yml` fails if
+  `pyproject.toml` declares a local `[tool.uv.sources]` path entry, so a machine-specific editable
+  path can never ship in a release.
 - **Added a plugin-pin auto-bump workflow.** `.github/workflows/plugin_pin_bump.yml` +
   `scripts/bump_plugin_pins.py` open a PR whenever a pinned plugin publishes a newer release. The
   bump is tag-only, so it also compares the plugin's declared node set at the new tag against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.11.0 - 2026-06-24
+## 0.10.1 - 2026-06-24
 
 - **Refreshed plugin manifest pins to the latest releases.** Bumped the `configs/plugins/` tags to
   the published standards-adoption releases: adaclip `v0.1.5`, dinomaly `v0.2.0`, deepeiou `v0.2.0`,

--- a/configs/plugins/adaclip.yaml
+++ b/configs/plugins/adaclip.yaml
@@ -7,7 +7,7 @@
 name: adaclip
 # AdaCLIP-based anomaly detection with advanced band selection
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-adaclip.git"
-tag: "v0.1.4"
+tag: "v0.1.5"
 package_name: "cuvis-ai-adaclip"
 capabilities:
 - class_name: cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector

--- a/configs/plugins/augment.yaml
+++ b/configs/plugins/augment.yaml
@@ -1,0 +1,40 @@
+# Augment plugin manifest (training-time data augmentation)
+#
+# To use Augment, declare `plugins: [augment]` in the pipeline yaml and point
+# the loader at the catalog directory that holds this manifest:
+#   uv run restore-pipeline --pipeline-path <pipeline>.yaml --plugins-dir configs/plugins
+
+name: augment
+# Local development override (optional):
+# path: "../../../cuvis-ai-augment"
+repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
+tag: "v0.3.0"
+package_name: "cuvis-ai-augment"
+capabilities:
+- class_name: cuvis_ai_augment.node.compose.AugmentationCompose
+  category: transform
+  tags: [torch, training]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <rect x=\"14\" y=\"14\" width=\"36\" height=\"36\" rx=\"3\" stroke-dasharray=\"5 4\"/>\n  <path d=\"M24 29a8 8 0 0 1 15-3\"/>\n  <path d=\"M39 22v4h-4\"/>\n  <path d=\"M40 35a8 8 0 0 1-15 3\"/>\n  <path d=\"M25 42v-4h4\"/>\n</svg>\n"
+  input_specs:
+    cube:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Hyperspectral cube [B, H, W, C] in float32
+    mask:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: true
+      description: Per-pixel mask [B, H, W] (int32 or bool)
+  output_specs:
+    cube:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Augmented cube [B, H, W, C]
+    mask:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: true
+      description: Augmented mask [B, H, W]
+  doc_summary: Applies a sequence of stochastic augmentation transforms to a cube and paired mask during training only.

--- a/configs/plugins/augment.yaml
+++ b/configs/plugins/augment.yaml
@@ -13,8 +13,8 @@ package_name: "cuvis-ai-augment"
 capabilities:
 - class_name: cuvis_ai_augment.node.compose.AugmentationCompose
   category: transform
-  tags: [torch, training]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <rect x=\"14\" y=\"14\" width=\"36\" height=\"36\" rx=\"3\" stroke-dasharray=\"5 4\"/>\n  <path d=\"M24 29a8 8 0 0 1 15-3\"/>\n  <path d=\"M39 22v4h-4\"/>\n  <path d=\"M40 35a8 8 0 0 1-15 3\"/>\n  <path d=\"M25 42v-4h4\"/>\n</svg>\n"
+  tags: [augmentation, mask, torch, training]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <rect x=\"14\" y=\"14\" width=\"36\" height=\"36\" rx=\"3\" stroke-dasharray=\"5 4\"/>\r\n  <path d=\"M24 29a8 8 0 0 1 15-3\"/>\r\n  <path d=\"M39 22v4h-4\"/>\r\n  <path d=\"M40 35a8 8 0 0 1-15 3\"/>\r\n  <path d=\"M25 42v-4h4\"/>\r\n</svg>\r\n"
   input_specs:
     cube:
       dtype: float32

--- a/configs/plugins/augment.yaml
+++ b/configs/plugins/augment.yaml
@@ -8,7 +8,7 @@ name: augment
 # Local development override (optional):
 # path: "../../../cuvis-ai-augment"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
-tag: "v0.3.0"
+tag: "v0.3.1"
 package_name: "cuvis-ai-augment"
 capabilities:
 - class_name: cuvis_ai_augment.node.compose.AugmentationCompose

--- a/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.1.0"
+tag: "v0.2.0"
 package_name: cuvis-ai-dataloader
 capabilities:
   - { class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule,              kind: data_module, data_module_name: cu3s,        extras: [cu3s, coco] }

--- a/configs/plugins/deepeiou.yaml
+++ b/configs/plugins/deepeiou.yaml
@@ -7,7 +7,7 @@
 name: deepeiou
 # path: "../../../../cuvis-ai-deepeiou/deepeiou-init"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-deepeiou.git"
-tag: "v0.1.2"
+tag: "v0.2.0"
 capabilities:
 - class_name: cuvis_ai_deepeiou.node.DeepEIoUTrack
   category: transform

--- a/configs/plugins/dinomaly.yaml
+++ b/configs/plugins/dinomaly.yaml
@@ -8,7 +8,7 @@ name: dinomaly
 # Local development override (optional):
 # path: "../../../cuvis-ai-dinomaly"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly.git"
-tag: "v0.1.5"
+tag: "v0.2.0"
 capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
   icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <circle cx=\"32\" cy=\"32\" r=\"22\" stroke-dasharray=\"4 3\"/>\r\n  <path d=\"M25 26a7 7 0 0 1 14 0c0 4-3.5 4.5-7 8v3\"/>\r\n  <circle cx=\"32\" cy=\"45\" r=\"1.2\" fill=\"#AAAAAA\" stroke=\"none\"/>\r\n</svg>\r\n"

--- a/configs/plugins/sam3.yaml
+++ b/configs/plugins/sam3.yaml
@@ -1,4 +1,4 @@
-# SAM3 Plugin Manifest (local development)
+# SAM3 Plugin Manifest
 #
 # To use SAM3, declare `plugins: [sam3]` in the pipeline yaml and point
 # the loader at the catalog directory that holds this manifest:
@@ -6,14 +6,11 @@
 
 name: sam3
 # SAM3-based video object tracking plugin.
-# Dev: local checkout (the features/nima/setuptools-coinstall branch relaxes
-# setuptools to <83 so sam3 co-installs with the cuvis-ai package in the
-# composed child env; the published v0.1.6 pins setuptools<81 and conflicts
-# with cuvis-ai's setuptools>=81). At release: swap back to repo + a published
-# tag that carries the relaxation.
-path: "../../../../cuvis-ai-sam3/cuvis-ai-sam3"
-# repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-# tag: "v0.1.6"
+# v0.1.7 relaxes setuptools to <83 so sam3 co-installs with the cuvis-ai package
+# in the composed child env (v0.1.6 pinned setuptools<81 and conflicted with
+# cuvis-ai's setuptools>=81).
+repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
+tag: "v0.1.7"
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TrackerInference

--- a/configs/plugins/trackeval.yaml
+++ b/configs/plugins/trackeval.yaml
@@ -7,7 +7,7 @@
 name: trackeval
 # TrackEval-based tracking metric nodes for HOTA, CLEAR, and Identity evaluation
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
-tag: "v0.1.2"
+tag: "v0.1.3"
 capabilities:
 - class_name: cuvis_ai_trackeval.node.HOTAMetricNode
   category: metric

--- a/configs/plugins/ultralytics.yaml
+++ b/configs/plugins/ultralytics.yaml
@@ -7,7 +7,7 @@
 name: ultralytics
 # path: "../../../../cuvis-ai-ultralytics/ultralytics-init"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-ultralytics.git"
-tag: "v0.1.2"
+tag: "v0.1.3"
 package_name: "cuvis-ai-ultralytics"
 capabilities:
 - class_name: cuvis_ai_ultralytics.node.YOLOPreprocess

--- a/scripts/bump_plugin_pins.py
+++ b/scripts/bump_plugin_pins.py
@@ -6,12 +6,24 @@ pinned one, rewrites the manifest's top-level ``tag:`` in place. Local-``path`` 
 self-reference) and untagged entries are skipped, as are entries whose pinned or latest
 tag is not a plain ``vX.Y.Z`` semver.
 
-Prints one ``bumped <name>: <old> -> <new>`` line per change and, when ``CHANGELOG.md``
-has an ``## [Unreleased]`` section, appends a single bump bullet there (otherwise the
-changelog is left to the human reviewer, since entries are hand-curated).
+This is a **tag-only** bump: the rich ``capabilities:`` block (ports, icon, category) is not
+regenerated, because that needs the plugin installed and introspected. To avoid silently
+shipping a stale node list when a release adds nodes, each bump runs a best-effort
+**capability drift** check: the plugin's own declared node set at the new tag is fetched and
+compared against the manifest's ``capabilities`` class names. The check is one-directional --
+a class the release declares but the manifest omits is flagged as a likely new node, while the
+manifest listing *more* nodes than the plugin's example is expected (example manifests are often
+curated subsets) and is not flagged. A flagged or unverifiable node set signals the workflow to
+mark the PR for manual capabilities regeneration; the tag is bumped either way. Removals are not
+detected by this heuristic (they surface at provision/load time).
+
+Prints one ``bumped <name>: <old> -> <new>`` line per change and, when ``CHANGELOG.md`` has an
+``## [Unreleased]`` section, appends a single bump bullet there (otherwise the changelog is left
+to the human reviewer, since entries are hand-curated).
 
 Used by ``.github/workflows/plugin_pin_bump.yml``; run from the repo root. Honors
-``GITHUB_TOKEN`` / ``GH_TOKEN`` from the environment to lift the GitHub API rate limit.
+``GITHUB_TOKEN`` / ``GH_TOKEN`` from the environment to lift the GitHub API rate limit and to
+read private plugin repos.
 """
 
 from __future__ import annotations
@@ -35,16 +47,49 @@ CATALOG = Path("configs/plugins")
 CHANGELOG = Path("CHANGELOG.md")
 
 
+def _token() -> str | None:
+    """Return a GitHub token from the environment, if present."""
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
 def _semver(tag: str) -> tuple[int, int, int] | None:
     """Return ``(major, minor, patch)`` for a ``vX.Y.Z`` tag, else ``None``."""
     match = _SEMVER.match(tag.strip())
     return (int(match[1]), int(match[2]), int(match[3])) if match else None
 
 
+def _extract_class_names(entries: object) -> set[str]:
+    """Pull node class names from a manifest ``capabilities`` / ``provides`` list."""
+    names: set[str] = set()
+    if not isinstance(entries, list):
+        return names
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("class_name"):
+            names.add(entry["class_name"])
+        elif isinstance(entry, str):
+            names.add(entry)
+    return names
+
+
+def _manifest_node_set(doc: dict) -> set[str] | None:
+    """Class-name set from a plugin manifest doc (capabilities/provides, top-level or nested)."""
+    for key in ("capabilities", "provides"):
+        if doc.get(key):
+            return _extract_class_names(doc[key])
+    plugins = doc.get("plugins")
+    if isinstance(plugins, dict):
+        names: set[str] = set()
+        for cfg in plugins.values():
+            if isinstance(cfg, dict):
+                names |= _extract_class_names(cfg.get("capabilities") or cfg.get("provides"))
+        return names or None
+    return None
+
+
 def _latest_release_tag(owner_repo: str) -> str | None:
     """Return the latest published release tag for ``owner/repo``, or ``None``."""
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "cuvis-ai-pin-bot"}
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = _token()
     if token:
         headers["Authorization"] = f"Bearer {token}"
     url = f"https://api.github.com/repos/{owner_repo}/releases/latest"
@@ -58,9 +103,50 @@ def _latest_release_tag(owner_repo: str) -> str | None:
         raise
 
 
-def bump_pins() -> list[tuple[str, str, str]]:
-    """Rewrite stale ``tag:`` pins in place; return the list of ``(name, old, new)``."""
+def _fetch_text(owner_repo: str, path: str, ref: str) -> str | None:
+    """Return a repo file's raw text at ``ref`` via the contents API, or ``None`` if absent."""
+    headers = {"Accept": "application/vnd.github.raw", "User-Agent": "cuvis-ai-pin-bot"}
+    token = _token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{owner_repo}/contents/{path}?ref={ref}"
+    request = urllib.request.Request(url, headers=headers)  # noqa: S310 - fixed github host
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def _released_node_set(owner_repo: str, name: str, tag: str) -> set[str] | None:
+    """Best-effort: the plugin's own declared node set at ``tag``, or ``None`` if not locatable."""
+    candidates = [
+        "examples/plugins.yaml",
+        f"examples/{name}/plugins.yaml",
+        f"configs/plugins/{name}.yaml",
+        "plugins.yaml",
+    ]
+    for path in candidates:
+        text = _fetch_text(owner_repo, path, tag)
+        if text is None:
+            continue
+        nodes = _manifest_node_set(yaml.safe_load(text) or {})
+        if nodes is not None:
+            return nodes
+    return None
+
+
+def bump_pins() -> tuple[list[tuple[str, str, str]], list[tuple[str, set[str]]]]:
+    """Rewrite stale ``tag:`` pins in place.
+
+    Returns ``(bumps, drifts)`` where ``bumps`` is ``(name, old, new)`` and ``drifts`` is
+    ``(name, added)``: node class names the release declares but the manifest omits. An empty
+    ``added`` set is the sentinel for "node set could not be verified".
+    """
     bumps: list[tuple[str, str, str]] = []
+    drifts: list[tuple[str, set[str]]] = []
     for manifest in sorted(CATALOG.glob("*.yaml")):
         data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
         name, repo, tag = data.get("name"), data.get("repo"), data.get("tag")
@@ -70,7 +156,8 @@ def bump_pins() -> list[tuple[str, str, str]]:
         if not match:
             print(f"skip {name}: unsupported repo url {repo}")
             continue
-        latest = _latest_release_tag(match.group(1))
+        owner_repo = match.group(1)
+        latest = _latest_release_tag(owner_repo)
         if not latest:
             print(f"skip {name}: no published release")
             continue
@@ -88,7 +175,20 @@ def bump_pins() -> list[tuple[str, str, str]]:
         manifest.write_text(new_text, encoding="utf-8")
         bumps.append((name, tag, latest))
         print(f"bumped {name}: {tag} -> {latest}")
-    return bumps
+
+        manifest_nodes = _extract_class_names(data.get("capabilities"))
+        released_nodes = _released_node_set(owner_repo, name, latest)
+        if released_nodes is None:
+            print(f"  ! {name}: could not verify node set at {latest}; check capabilities manually")
+            drifts.append((name, set()))
+        elif released_nodes - manifest_nodes:
+            # One-directional: a class the release declares but the catalog manifest omits is a
+            # likely new node. The reverse (manifest has more) is expected, since a plugin's own
+            # example manifest is often a curated subset, so it is not treated as drift.
+            added = released_nodes - manifest_nodes
+            print(f"  ! {name}: manifest is missing node(s) this release declares: {sorted(added)}")
+            drifts.append((name, added))
+    return bumps, drifts
 
 
 def append_changelog(bumps: list[tuple[str, str, str]]) -> None:
@@ -106,9 +206,17 @@ def append_changelog(bumps: list[tuple[str, str, str]]) -> None:
     print("CHANGELOG: appended bump bullet under [Unreleased]")
 
 
+def _set_output(key: str, value: str) -> None:
+    """Write a GitHub Actions step output, if running under Actions."""
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as handle:
+            handle.write(f"{key}={value}\n")
+
+
 def main() -> None:
-    """Bump stale pins and emit a summary (consumed by the PR-opening workflow step)."""
-    bumps = bump_pins()
+    """Bump stale pins, report drift, and emit outputs the PR-opening workflow consumes."""
+    bumps, drifts = bump_pins()
     if not bumps:
         print("no plugin pins to bump")
         return
@@ -116,6 +224,16 @@ def main() -> None:
     print(f"\n{len(bumps)} pin(s) bumped:")
     for name, old, new in bumps:
         print(f"  - {name}: {old} -> {new}")
+    if drifts:
+        print("\n>>> CAPABILITIES REVIEW NEEDED <<<")
+        print("A bumped release declares nodes the manifest may be missing (or its node set could")
+        print("not be verified), so the capabilities block likely needs a manual regen for:")
+        for name, added in drifts:
+            if not added:
+                print(f"  - {name}: node set could not be verified at the new tag")
+            else:
+                print(f"  - {name}: missing node(s): {sorted(added)}")
+        _set_output("drift", "true")
 
 
 if __name__ == "__main__":

--- a/scripts/bump_plugin_pins.py
+++ b/scripts/bump_plugin_pins.py
@@ -1,0 +1,122 @@
+"""Refresh plugin manifest tag pins from each plugin's latest GitHub release.
+
+Reads ``configs/plugins/*.yaml``; for every plugin sourced from a git ``repo`` + ``tag``,
+queries the repo's latest published release on GitHub and, when that tag is newer than the
+pinned one, rewrites the manifest's top-level ``tag:`` in place. Local-``path`` (dev /
+self-reference) and untagged entries are skipped, as are entries whose pinned or latest
+tag is not a plain ``vX.Y.Z`` semver.
+
+Prints one ``bumped <name>: <old> -> <new>`` line per change and, when ``CHANGELOG.md``
+has an ``## [Unreleased]`` section, appends a single bump bullet there (otherwise the
+changelog is left to the human reviewer, since entries are hand-curated).
+
+Used by ``.github/workflows/plugin_pin_bump.yml``; run from the repo root. Honors
+``GITHUB_TOKEN`` / ``GH_TOKEN`` from the environment to lift the GitHub API rate limit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+_GITHUB = re.compile(r"(?:git@github\.com:|https?://github\.com/)(.+?)(?:\.git)?$")
+_SEMVER = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+# Matches exactly one top-level (column-0) tag line; capabilities entries are indented
+# and commented lines start with '#', so neither is matched.
+_TAG_LINE = re.compile(r'^(tag:[ \t]*)(["\']?)v\d+\.\d+\.\d+\2[ \t]*$', re.MULTILINE)
+
+CATALOG = Path("configs/plugins")
+CHANGELOG = Path("CHANGELOG.md")
+
+
+def _semver(tag: str) -> tuple[int, int, int] | None:
+    """Return ``(major, minor, patch)`` for a ``vX.Y.Z`` tag, else ``None``."""
+    match = _SEMVER.match(tag.strip())
+    return (int(match[1]), int(match[2]), int(match[3])) if match else None
+
+
+def _latest_release_tag(owner_repo: str) -> str | None:
+    """Return the latest published release tag for ``owner/repo``, or ``None``."""
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "cuvis-ai-pin-bot"}
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"https://api.github.com/repos/{owner_repo}/releases/latest"
+    request = urllib.request.Request(url, headers=headers)  # noqa: S310 - fixed github host
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            return json.load(response).get("tag_name")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None  # no published release yet
+        raise
+
+
+def bump_pins() -> list[tuple[str, str, str]]:
+    """Rewrite stale ``tag:`` pins in place; return the list of ``(name, old, new)``."""
+    bumps: list[tuple[str, str, str]] = []
+    for manifest in sorted(CATALOG.glob("*.yaml")):
+        data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+        name, repo, tag = data.get("name"), data.get("repo"), data.get("tag")
+        if not (name and repo and tag):
+            continue  # local-path / self-reference / non-tagged entry
+        match = _GITHUB.match(repo)
+        if not match:
+            print(f"skip {name}: unsupported repo url {repo}")
+            continue
+        latest = _latest_release_tag(match.group(1))
+        if not latest:
+            print(f"skip {name}: no published release")
+            continue
+        current, newest = _semver(tag), _semver(latest)
+        if current is None or newest is None:
+            print(f"skip {name}: non-semver tag (pinned {tag!r}, latest {latest!r})")
+            continue
+        if newest <= current:
+            continue
+        text = manifest.read_text(encoding="utf-8")
+        new_text, count = _TAG_LINE.subn(rf"\g<1>\g<2>{latest}\g<2>", text)
+        if count != 1:
+            print(f"WARN {name}: expected one top-level tag line, found {count}; skipped")
+            continue
+        manifest.write_text(new_text, encoding="utf-8")
+        bumps.append((name, tag, latest))
+        print(f"bumped {name}: {tag} -> {latest}")
+    return bumps
+
+
+def append_changelog(bumps: list[tuple[str, str, str]]) -> None:
+    """Append a bump bullet under an existing ``## [Unreleased]`` heading, if present."""
+    if not CHANGELOG.exists():
+        return
+    text = CHANGELOG.read_text(encoding="utf-8")
+    marker = "## [Unreleased]"
+    if marker not in text:
+        print("CHANGELOG: no [Unreleased] section; leaving the changelog to the reviewer")
+        return
+    listed = ", ".join(f"{name} {old} -> {new}" for name, old, new in bumps)
+    bullet = f"- Bumped plugin manifest pins: {listed}."
+    CHANGELOG.write_text(text.replace(marker, f"{marker}\n\n{bullet}", 1), encoding="utf-8")
+    print("CHANGELOG: appended bump bullet under [Unreleased]")
+
+
+def main() -> None:
+    """Bump stale pins and emit a summary (consumed by the PR-opening workflow step)."""
+    bumps = bump_pins()
+    if not bumps:
+        print("no plugin pins to bump")
+        return
+    append_changelog(bumps)
+    print(f"\n{len(bumps)} pin(s) bumped:")
+    for name, old, new in bumps:
+        print(f"  - {name}: {old} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch_plugin_pyprojects.py
+++ b/scripts/fetch_plugin_pyprojects.py
@@ -24,25 +24,26 @@ _GITHUB = re.compile(r"(?:git@github\.com:|https?://github\.com/)(.+?)(?:\.git)?
 def main() -> None:
     cache = Path.home() / ".cuvis_plugins"
     catalog = Path("configs/plugins")
+    # One file = one plugin: the source lives in the top-level `name` / `repo` / `tag`
+    # keys (not a nested `plugins:` mapping). Local-`path` and untagged entries are skipped.
     for manifest in sorted(catalog.glob("*.yaml")):
         data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
-        for name, cfg in (data.get("plugins") or {}).items():
-            repo, tag = cfg.get("repo"), cfg.get("tag")
-            if not (repo and tag):
-                print(f"skip {name}: local-path or non-tagged plugin")
-                continue
-            match = _GITHUB.match(repo)
-            if not match:
-                print(f"skip {name}: unsupported repo url {repo}")
-                continue
-            url = f"https://raw.githubusercontent.com/{match.group(1)}/{tag}/pyproject.toml"
-            dest = cache / f"{name}@{tag}"
-            dest.mkdir(parents=True, exist_ok=True)
-            try:
-                urllib.request.urlretrieve(url, dest / "pyproject.toml")
-                print(f"fetched {name}@{tag} <- {url}")
-            except Exception as exc:  # noqa: BLE001 - audit warns on a missing pyproject
-                print(f"WARN {name}@{tag}: fetch failed ({exc})")
+        name, repo, tag = data.get("name"), data.get("repo"), data.get("tag")
+        if not (repo and tag):
+            print(f"skip {name or manifest.stem}: local-path or non-tagged plugin")
+            continue
+        match = _GITHUB.match(repo)
+        if not match:
+            print(f"skip {name}: unsupported repo url {repo}")
+            continue
+        url = f"https://raw.githubusercontent.com/{match.group(1)}/{tag}/pyproject.toml"
+        dest = cache / f"{name}@{tag}"
+        dest.mkdir(parents=True, exist_ok=True)
+        try:
+            urllib.request.urlretrieve(url, dest / "pyproject.toml")
+            print(f"fetched {name}@{tag} <- {url}")
+        except Exception as exc:  # noqa: BLE001 - audit warns on a missing pyproject
+            print(f"WARN {name}@{tag}: fetch failed ({exc})")
 
 
 if __name__ == "__main__":

--- a/tests/plugins/test_augment_manifest_sync.py
+++ b/tests/plugins/test_augment_manifest_sync.py
@@ -1,4 +1,4 @@
-"""Validate the selective DeepEIoU plugin manifest."""
+"""Validate the augment plugin manifest."""
 
 from __future__ import annotations
 
@@ -16,27 +16,25 @@ pytestmark = pytest.mark.unit
 # guard against a plugin's exposed surface drifting out of sync with this manifest.
 SEMVER_TAG = re.compile(r"v\d+\.\d+\.\d+")
 
-DEEPEIOU_MANIFEST_PATH = Path("configs/plugins/deepeiou.yaml")
-PLUGIN_NAME = "deepeiou"
-EXPECTED_REPO = "https://github.com/cubert-hyperspectral/cuvis-ai-deepeiou.git"
+AUGMENT_MANIFEST_PATH = Path("configs/plugins/augment.yaml")
+PLUGIN_NAME = "augment"
+EXPECTED_REPO = "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
 EXPECTED_PROVIDES = [
-    "cuvis_ai_deepeiou.node.DeepEIoUTrack",
-    "cuvis_ai_deepeiou.node.OSNetExtractor",
-    "cuvis_ai_deepeiou.node.ResNetExtractor",
+    "cuvis_ai_augment.node.compose.AugmentationCompose",
 ]
 
 
-def test_deepeiou_manifest_exists() -> None:
-    assert DEEPEIOU_MANIFEST_PATH.exists(), f"Missing DeepEIoU manifest: {DEEPEIOU_MANIFEST_PATH}"
+def test_augment_manifest_exists() -> None:
+    assert AUGMENT_MANIFEST_PATH.exists(), f"Missing augment manifest: {AUGMENT_MANIFEST_PATH}"
 
 
-def test_deepeiou_manifest_contains_only_deepeiou_plugin() -> None:
-    manifest = load_plugin_manifest(DEEPEIOU_MANIFEST_PATH)
+def test_augment_manifest_contains_only_augment_plugin() -> None:
+    manifest = load_plugin_manifest(AUGMENT_MANIFEST_PATH)
     assert manifest.name == PLUGIN_NAME
 
 
-def test_deepeiou_manifest_matches_expected_release() -> None:
-    manifest = load_plugin_manifest(DEEPEIOU_MANIFEST_PATH)
+def test_augment_manifest_matches_expected_release() -> None:
+    manifest = load_plugin_manifest(AUGMENT_MANIFEST_PATH)
     plugin = manifest
 
     assert getattr(plugin, "repo", None) == EXPECTED_REPO

--- a/tests/plugins/test_plugin_manifest_sync.py
+++ b/tests/plugins/test_plugin_manifest_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -9,10 +10,15 @@ from cuvis_ai_schemas.plugin import load_plugin_manifest
 
 pytestmark = pytest.mark.unit
 
+# The pinned tag is intentionally not frozen here: pins are refreshed (manually or by
+# the plugin-pin-bump workflow) whenever a plugin releases, so this asserts the tag is
+# present and well-formed rather than a specific value. The node set below is the real
+# guard against a plugin's exposed surface drifting out of sync with this manifest.
+SEMVER_TAG = re.compile(r"v\d+\.\d+\.\d+")
+
 TRACKEVAL_MANIFEST_PATH = Path("configs/plugins/trackeval.yaml")
 PLUGIN_NAME = "trackeval"
 EXPECTED_REPO = "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
-EXPECTED_TAG = "v0.1.2"
 EXPECTED_PROVIDES = [
     "cuvis_ai_trackeval.node.HOTAMetricNode",
     "cuvis_ai_trackeval.node.CLEARMetricNode",
@@ -36,5 +42,6 @@ def test_trackeval_manifest_matches_expected_release() -> None:
     plugin = manifest
 
     assert getattr(plugin, "repo", None) == EXPECTED_REPO
-    assert getattr(plugin, "tag", None) == EXPECTED_TAG
+    tag = getattr(plugin, "tag", None)
+    assert tag is not None and SEMVER_TAG.fullmatch(tag), f"unexpected tag: {tag!r}"
     assert [node.class_name for node in plugin.capabilities] == EXPECTED_PROVIDES

--- a/tests/plugins/test_ultralytics_manifest_sync.py
+++ b/tests/plugins/test_ultralytics_manifest_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -9,10 +10,15 @@ from cuvis_ai_schemas.plugin import load_plugin_manifest
 
 pytestmark = pytest.mark.unit
 
+# The pinned tag is intentionally not frozen here: pins are refreshed (manually or by
+# the plugin-pin-bump workflow) whenever a plugin releases, so this asserts the tag is
+# present and well-formed rather than a specific value. The node set below is the real
+# guard against a plugin's exposed surface drifting out of sync with this manifest.
+SEMVER_TAG = re.compile(r"v\d+\.\d+\.\d+")
+
 ULTRALYTICS_MANIFEST_PATH = Path("configs/plugins/ultralytics.yaml")
 PLUGIN_NAME = "ultralytics"
 EXPECTED_REPO = "https://github.com/cubert-hyperspectral/cuvis-ai-ultralytics.git"
-EXPECTED_TAG = "v0.1.2"
 EXPECTED_PROVIDES = [
     "cuvis_ai_ultralytics.node.YOLOPreprocess",
     "cuvis_ai_ultralytics.node.YOLO26Detection",
@@ -36,5 +42,6 @@ def test_ultralytics_manifest_matches_expected_release() -> None:
     plugin = manifest
 
     assert getattr(plugin, "repo", None) == EXPECTED_REPO
-    assert getattr(plugin, "tag", None) == EXPECTED_TAG
+    tag = getattr(plugin, "tag", None)
+    assert tag is not None and SEMVER_TAG.fullmatch(tag), f"unexpected tag: {tag!r}"
     assert [node.class_name for node in plugin.capabilities] == EXPECTED_PROVIDES


### PR DESCRIPTION
## Summary

Refreshes the plugin manifest pins to the latest releases, registers the augment plugin, and adds CI that keeps the pins current automatically. Targets `0.11.0`.

## Manifest pin refresh (`configs/plugins/`)

- adaclip `v0.1.4` -> `v0.1.5`
- dinomaly `v0.1.5` -> `v0.2.0`
- deepeiou `v0.1.2` -> `v0.2.0`
- trackeval `v0.1.2` -> `v0.1.3`
- ultralytics `v0.1.2` -> `v0.1.3`
- cuvis_ai_dataloader `v0.1.0` -> `v0.2.0`

These are tag-only bumps: the releases carried no node or port changes, so each manifest's `capabilities:` block is unchanged.

## sam3: local path -> published tag

`configs/plugins/sam3.yaml` swaps from the local dev `path:` to `repo:` + `tag: v0.1.7`. v0.1.7 relaxes `setuptools<83`, resolving the `setuptools>=81` conflict that had forced the local checkout. No released-plugin manifest now carries an uncommitted local path.

## augment registration

New `configs/plugins/augment.yaml` (capabilities format, `tag: v0.3.0`) exposing `AugmentationCompose` for training-time cube/mask augmentation, plus `tests/plugins/test_augment_manifest_sync.py`. This **supersedes #33**, which added an augment manifest in the deprecated nested `plugins:`/`provides:` format pinned to v0.1.1.

## Auto-bump CI

- `scripts/bump_plugin_pins.py` + `.github/workflows/plugin_pin_bump.yml` open a PR whenever a pinned plugin publishes a newer release (cron + manual dispatch). It authenticates as a GitHub App (`PIN_BUMP_APP_ID` / `PIN_BUMP_APP_PRIVATE_KEY`) so the bot's PR triggers CI; the job is guarded on the App id being present. The App is provisioned and scoped to this repo only; the workflow activates once this lands on `main`.
- The per-plugin manifest-sync tests now assert the pinned tag's *shape* (`vX.Y.Z`) instead of a frozen value, so a refresh touches only YAML.
- Fixed `scripts/fetch_plugin_pyprojects.py` to read the one-file manifest format; it had silently skipped every manifest in the registry-compat audit.

## Verification

- `ruff check` + `ruff format --check`: clean
- All plugin manifests load via `cuvis_ai_schemas.plugin.load_plugin_manifest`
- `pytest -m "not slow and not gpu"`: 944 passed, 2 skipped
- `bump_plugin_pins.py` dry-run: no pending bumps (pins are current)
