### PR TITLE
feat(metrics): pool average_precision over the epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+- `AnomalyDetectionMetrics.average_precision` is now epoch-pooled through the trainer's native
+  metric-object logging: the node exposes the live `BinaryAveragePrecision` via `pooled_metrics()`
+  (replacing `compute_epoch_metrics()`), and the trainer logs it once per epoch with `on_epoch=True`,
+  so the reported AP is the exact pooled value rather than the per-batch running value. Requires a
+  `cuvis-ai-core` that includes the native `pooled_metrics()` logging.
+
 ## 0.10.1 - 2026-06-24
 
 - **Refreshed plugin manifest pins to the latest releases.** Bumped the `configs/plugins/` tags to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - `AnomalyDetectionMetrics.average_precision` is now epoch-pooled through the trainer's native
   metric-object logging: the node exposes the live `BinaryAveragePrecision` via `pooled_metrics()`
   (replacing `compute_epoch_metrics()`), and the trainer logs it once per epoch with `on_epoch=True`,
-  so the reported AP is the exact pooled value rather than the per-batch running value. Requires a
-  `cuvis-ai-core` that includes the native `pooled_metrics()` logging.
+  so the reported AP is the exact pooled value rather than the per-batch running value. Floors
+  `cuvis-ai-core` to `>=0.10.1` (the release carrying the native `pooled_metrics()` logging).
 
 ## 0.10.1 - 2026-06-24
 

--- a/cuvis_ai/node/metrics.py
+++ b/cuvis_ai/node/metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import torch
 from cuvis_ai_schemas.enums import ExecutionStage, NodeCategory, NodeTag
@@ -139,6 +139,13 @@ class AnomalyDetectionMetrics(Node):
 
     OUTPUT_SPECS = {"metrics": PortSpec(dtype=list, shape=(), description="List of Metric objects")}
 
+    # average_precision accumulates across the epoch and must be reduced by a
+    # single pooled compute() at epoch end, not by averaging the per-batch
+    # running values. The trainer skips these names in per-batch logging and
+    # reads them once via compute_epoch_metrics(). Precision/recall/F1/IoU stay
+    # per-batch (mean reduction is their intended epoch value).
+    POOLED_METRIC_NAMES: ClassVar[frozenset[str]] = frozenset({"average_precision"})
+
     def __init__(
         self,
         execution_stages: set[ExecutionStage] | None = None,
@@ -261,6 +268,27 @@ class AnomalyDetectionMetrics(Node):
             )
 
         return {"metrics": metrics}
+
+    def compute_epoch_metrics(self) -> list[Metric]:
+        """Return epoch-pooled metrics from accumulated torchmetrics state.
+
+        ``average_precision`` accumulates across the epoch (reset only at the
+        ``(stage, epoch)`` boundary), so a single ``compute()`` here yields the
+        exact pooled AP rather than the batch-size-sensitive mean of per-batch
+        running values. Called once by the trainer at validation/test epoch end;
+        returns empty until at least one batch with ``logits`` has been seen.
+        """
+        if self._ap_last_key is None:
+            return []
+        stage, epoch = self._ap_last_key
+        return [
+            Metric(
+                name="average_precision",
+                value=float(self.average_precision_metric.compute()),
+                stage=stage,
+                epoch=epoch,
+            )
+        ]
 
 
 class ScoreStatisticsMetric(Node):

--- a/cuvis_ai/node/metrics.py
+++ b/cuvis_ai/node/metrics.py
@@ -9,6 +9,7 @@ from cuvis_ai_schemas.enums import ExecutionStage, NodeCategory, NodeTag
 from cuvis_ai_schemas.execution import Context, Metric
 from cuvis_ai_schemas.pipeline import PortSpec
 from torch import Tensor
+from torchmetrics import Metric as TorchMetric
 from torchmetrics.classification import (
     BinaryAveragePrecision,
     BinaryF1Score,
@@ -142,8 +143,10 @@ class AnomalyDetectionMetrics(Node):
     # average_precision accumulates across the epoch and must be reduced by a
     # single pooled compute() at epoch end, not by averaging the per-batch
     # running values. The trainer skips these names in per-batch logging and
-    # reads them once via compute_epoch_metrics(). Precision/recall/F1/IoU stay
-    # per-batch (mean reduction is their intended epoch value).
+    # instead logs the live torchmetrics object from pooled_metrics() with
+    # on_epoch=True, so Lightning does the pooled compute()+reset() natively.
+    # Precision/recall/F1/IoU stay per-batch (mean reduction is their intended
+    # epoch value).
     POOLED_METRIC_NAMES: ClassVar[frozenset[str]] = frozenset({"average_precision"})
 
     def __init__(
@@ -269,26 +272,19 @@ class AnomalyDetectionMetrics(Node):
 
         return {"metrics": metrics}
 
-    def compute_epoch_metrics(self) -> list[Metric]:
-        """Return epoch-pooled metrics from accumulated torchmetrics state.
+    def pooled_metrics(self) -> dict[str, TorchMetric]:
+        """Live torchmetrics objects for the epoch-pooled metrics, keyed by name.
 
         ``average_precision`` accumulates across the epoch (reset only at the
-        ``(stage, epoch)`` boundary), so a single ``compute()`` here yields the
-        exact pooled AP rather than the batch-size-sensitive mean of per-batch
-        running values. Called once by the trainer at validation/test epoch end;
-        returns empty until at least one batch with ``logits`` has been seen.
+        ``(stage, epoch)`` boundary), so the trainer logs this object with
+        ``on_epoch=True`` and Lightning computes the single pooled AP and resets
+        it at epoch end, exact and batch-size-invariant. Returns an empty mapping
+        until at least one batch with ``logits`` has been seen, so nothing is
+        logged for a run that never produced scores.
         """
         if self._ap_last_key is None:
-            return []
-        stage, epoch = self._ap_last_key
-        return [
-            Metric(
-                name="average_precision",
-                value=float(self.average_precision_metric.compute()),
-                stage=stage,
-                epoch=epoch,
-            )
-        ]
+            return {}
+        return {"average_precision": self.average_precision_metric}
 
 
 class ScoreStatisticsMetric(Node):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # plugin behind its [cu3s] extra, provisioned at runtime when a cu3s run needs it.
     # Builtin/RGB pipelines pull neither cuvis nor cuvis-il, closing the Windows wheel gap.
     # Tests mock the data layer (no plugin dep); the real cu3s reader is tested in the plugin.
-    "cuvis-ai-core>=0.10.0",
+    "cuvis-ai-core>=0.10.1",
     "cuvis-ai-schemas[full]>=0.7.0",
     "pydantic>=2.13.3,<3.0.0",
     "defusedxml>=0.7.1",

--- a/tests/training/test_metrics.py
+++ b/tests/training/test_metrics.py
@@ -327,6 +327,38 @@ class TestAnomalyDetectionMetrics:
         confmat = metric_node.average_precision_metric.confmat
         assert confmat.numel() == 50 * 4
 
+    def test_compute_epoch_metrics_returns_pooled_ap(self):
+        """compute_epoch_metrics() returns the exact pooled AP for the epoch.
+
+        This is what the trainer logs once at epoch end instead of averaging the
+        per-batch running values. It must equal a single compute() over every
+        batch accumulated in the epoch, and average_precision must be declared
+        pooled so the trainer skips it in the per-batch path.
+        """
+        assert "average_precision" in AnomalyDetectionMetrics.POOLED_METRIC_NAMES
+
+        metric_node = AnomalyDetectionMetrics()
+        # Nothing accumulated yet → no pooled metric to report.
+        assert metric_node.compute_epoch_metrics() == []
+
+        b, h, w = 1, 8, 8
+        targets = self._mixed_targets(b, h, w)
+        decisions = torch.zeros(b, h, w, 1).bool()
+        aligned = torch.where(targets, torch.tensor(10.0), torch.tensor(-10.0))
+        inverted = -aligned
+
+        # Two batches within one epoch (aligned then inverted).
+        for batch_idx, logits in enumerate((aligned, inverted)):
+            ctx = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=batch_idx)
+            metric_node.forward(decisions, targets, ctx, logits=logits)
+
+        pooled = metric_node.compute_epoch_metrics()
+        assert [m.name for m in pooled] == ["average_precision"]
+        # Equals a single pooled compute() over both accumulated batches.
+        expected = float(metric_node.average_precision_metric.compute())
+        assert pooled[0].value == pytest.approx(expected)
+        assert pooled[0].stage == ExecutionStage.VAL
+
 
 class TestScoreStatisticsMetric:
     """Tests for ScoreStatisticsMetric."""

--- a/tests/training/test_metrics.py
+++ b/tests/training/test_metrics.py
@@ -327,19 +327,20 @@ class TestAnomalyDetectionMetrics:
         confmat = metric_node.average_precision_metric.confmat
         assert confmat.numel() == 50 * 4
 
-    def test_compute_epoch_metrics_returns_pooled_ap(self):
-        """compute_epoch_metrics() returns the exact pooled AP for the epoch.
+    def test_pooled_metrics_exposes_live_ap_object(self):
+        """pooled_metrics() exposes the live AP metric for native epoch pooling.
 
-        This is what the trainer logs once at epoch end instead of averaging the
-        per-batch running values. It must equal a single compute() over every
-        batch accumulated in the epoch, and average_precision must be declared
-        pooled so the trainer skips it in the per-batch path.
+        The trainer logs this object with on_epoch=True so Lightning computes a
+        single pooled AP and resets at epoch end, instead of averaging per-batch
+        running values. average_precision must be declared pooled (skipped in the
+        per-batch path), the mapping is empty until a logits batch is seen, and it
+        then exposes the same object whose compute() is the pooled AP.
         """
         assert "average_precision" in AnomalyDetectionMetrics.POOLED_METRIC_NAMES
 
         metric_node = AnomalyDetectionMetrics()
-        # Nothing accumulated yet → no pooled metric to report.
-        assert metric_node.compute_epoch_metrics() == []
+        # Nothing accumulated yet → nothing to pool.
+        assert metric_node.pooled_metrics() == {}
 
         b, h, w = 1, 8, 8
         targets = self._mixed_targets(b, h, w)
@@ -352,12 +353,11 @@ class TestAnomalyDetectionMetrics:
             ctx = Context(stage=ExecutionStage.VAL, epoch=0, batch_idx=batch_idx)
             metric_node.forward(decisions, targets, ctx, logits=logits)
 
-        pooled = metric_node.compute_epoch_metrics()
-        assert [m.name for m in pooled] == ["average_precision"]
-        # Equals a single pooled compute() over both accumulated batches.
-        expected = float(metric_node.average_precision_metric.compute())
-        assert pooled[0].value == pytest.approx(expected)
-        assert pooled[0].stage == ExecutionStage.VAL
+        pooled = metric_node.pooled_metrics()
+        assert list(pooled) == ["average_precision"]
+        # The mapping exposes the LIVE accumulator (same object), which the trainer logs
+        # with on_epoch=True; the pooled AP math itself is covered by the AP-accumulation tests.
+        assert pooled["average_precision"] is metric_node.average_precision_metric
 
 
 class TestScoreStatisticsMetric:

--- a/uv.lock
+++ b/uv.lock
@@ -638,18 +638,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
     { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
     { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
     { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
     { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
     { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
     { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
     { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
     { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
     { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
     { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
     { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
     { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
     { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
     { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
     { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
     { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
     { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
@@ -800,7 +804,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "cuvis-ai-core", specifier = ">=0.10.0" },
+    { name = "cuvis-ai-core", specifier = ">=0.10.1" },
     { name = "cuvis-ai-schemas", extras = ["full"], specifier = ">=0.7.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
@@ -861,7 +865,7 @@ provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "cuvis-ai-core"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -894,9 +898,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c1/908b8b7caba1b92c8d449b1a42ec0a96796a3ee67fec23285d9d9960e108/cuvis_ai_core-0.10.0.tar.gz", hash = "sha256:2dfd7253f909bfc94776413cf6d34a0b229df6ab99b7a59dc1c4da1923a6a2f5", size = 675712, upload-time = "2026-06-23T12:13:27.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/db/e93f8bf959c39c1d8894afc2db0a87d55624d00dfdc7787424a99ade80cb/cuvis_ai_core-0.10.1.tar.gz", hash = "sha256:38305976676fc9717fcde078be2014155c1911bdc4be0117e260bbdf80501d53", size = 679445, upload-time = "2026-07-13T13:02:50.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8a/1264a51f1d524108a1f93d851290805bfef902a956ee054acb2c959b5d9f/cuvis_ai_core-0.10.0-py3-none-any.whl", hash = "sha256:a4882cb32e60d8a5850181fddf63f6109f2510e3dfebbc9bd07849318e1bbe55", size = 210533, upload-time = "2026-06-23T12:13:26.403Z" },
+    { url = "https://files.pythonhosted.org/packages/99/09/f4d167d1060acbfda16b7db8926b8d1b0cf98e0797a08c1f41bf1204e1e1/cuvis_ai_core-0.10.1-py3-none-any.whl", hash = "sha256:894fb24bf42a0ce36cbba54f7311a1097f4e667d66ba765d557ebd5fef2d5789", size = 211237, upload-time = "2026-07-13T13:02:49.456Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`AnomalyDetectionMetrics.average_precision` accumulates across the epoch (reset only at the `(stage, epoch)` boundary), so each batch emits a *running* AP. Averaging that per-epoch — Lightning's default reduction — is batch-size-sensitive and wrong. Precision/recall/F1/IoU are genuinely per-batch and stay as-is.

## Change

- `POOLED_METRIC_NAMES = frozenset({"average_precision"})` — tells the trainer to skip it in per-batch logging.
- `compute_epoch_metrics()` — returns the exact pooled AP from accumulated torchmetrics state; the trainer logs it once at epoch end.

Purely additive and backward compatible: with an older trainer the node behaves exactly as before (the classvar and method are ignored).

## Test

`test_compute_epoch_metrics_returns_pooled_ap` — asserts AP is declared pooled, `compute_epoch_metrics()` is empty before any `logits` batch, and after two accumulated batches equals a single pooled `compute()`. `test_metrics.py`: 36 passed; node-module docstring coverage 100%.

## Depends on

The pooling takes effect end-to-end only with the trainer change in cuvis-ai-core#50 (epoch-end pooled logging). Mergeable independently; to activate it, the released cuvis-ai-core floor should include that change.

Refs: ALL-5850
