### PR TITLE
docs(changelog): stamp 0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.10.2 - 2026-07-13
 
 - `AnomalyDetectionMetrics.average_precision` is now epoch-pooled through the trainer's native
   metric-object logging: the node exposes the live `BinaryAveragePrecision` via `pooled_metrics()`


### PR DESCRIPTION
Stamps the `[Unreleased]` heading to `0.10.2 - 2026-07-13` for the release carrying the native average_precision epoch pooling (#54). One-line CHANGELOG change; the `v0.10.2` tag follows once this lands.