### PR TITLE
feat(losses): add DiceLoss and CrossEntropyLoss segmentation loss nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
 - Bumped the `cuvis_ai_builtin` manifest pin v0.11.5 -> v0.12.0 so composed child environments install the released cuvis-ai matching the host.
 
 ## 0.12.0 - 2026-08-20
@@ -124,8 +125,6 @@
   `CocoTrackMaskWriter`.
 - **Dropped the abstract `SAM3TrackerInference` entry from `configs/plugins/sam3.yaml`.** Base
   classes are not instantiable from pipelines, so the manifest now lists only concrete nodes.
-
-- **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
 
 ## 0.11.0 - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@
 - **Dropped the abstract `SAM3TrackerInference` entry from `configs/plugins/sam3.yaml`.** Base
   classes are not instantiable from pipelines, so the manifest now lists only concrete nodes.
 
+- **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
+
 ## 0.11.0 - 2026-07-14
 
 - **Docs: the node catalog now lists plugin capabilities.** The Catalogs â†’ Nodes generator reads

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -1593,7 +1593,7 @@ capabilities:
       dtype: int32
       shape: [-1, -1, -1]
       optional: false
-      description: Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)
+      description: Integer class-index mask [B, H, W]; cast to int64 internally
   output_specs:
     loss:
       dtype: float32
@@ -1637,7 +1637,7 @@ capabilities:
       dtype: int32
       shape: [-1, -1, -1]
       optional: false
-      description: Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)
+      description: Integer class-index mask [B, H, W]; cast to int64 internally
   output_specs:
     loss:
       dtype: float32

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -1579,6 +1579,28 @@ capabilities:
       optional: false
       description: Scalar BCE loss value
   doc_summary: Binary cross-entropy loss for anomaly detection with logits.
+- class_name: cuvis_ai.node.losses.CrossEntropyLoss
+  category: loss
+  tags: [differentiable, segmentation, torch, training]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#9A5DD4\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <path d=\"M14 18c8 0 12 8 18 18s12 14 22 14\"/>\n  <path d=\"M48 44l6 6-6 6\" transform=\"translate(0 -6)\"/>\n</svg>\n"
+  input_specs:
+    logits:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Per-pixel class logits [B, H, W, num_classes]
+    targets:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)
+  output_specs:
+    loss:
+      dtype: float32
+      shape: []
+      optional: false
+      description: Scalar loss value
+  doc_summary: Pixel-wise cross-entropy over dense segmentation logits (``K >= 2``).
 - class_name: cuvis_ai.node.losses.DeepSVDDSoftBoundaryLoss
   category: loss
   tags: [anomaly, differentiable, torch, training]
@@ -1601,6 +1623,28 @@ capabilities:
       optional: false
       description: Deep SVDD soft-boundary loss
   doc_summary: Soft-boundary Deep SVDD objective operating on BHWD embeddings.
+- class_name: cuvis_ai.node.losses.DiceLoss
+  category: loss
+  tags: [differentiable, segmentation, torch, training]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#9A5DD4\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <path d=\"M14 18c8 0 12 8 18 18s12 14 22 14\"/>\n  <path d=\"M48 44l6 6-6 6\" transform=\"translate(0 -6)\"/>\n</svg>\n"
+  input_specs:
+    logits:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Per-pixel class logits [B, H, W, num_classes]
+    targets:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)
+  output_specs:
+    loss:
+      dtype: float32
+      shape: []
+      optional: false
+      description: Scalar loss value
+  doc_summary: Soft Dice loss over dense segmentation logits.
 - class_name: cuvis_ai.node.losses.DistinctnessLoss
   category: loss
   tags: [differentiable, torch, training]

--- a/cuvis_ai/node/__init__.py
+++ b/cuvis_ai/node/__init__.py
@@ -77,7 +77,12 @@ from cuvis_ai.node.json_file import (
     TrackingResultsReader,
 )
 from cuvis_ai.node.labels import BinaryAnomalyLabelMapper
-from cuvis_ai.node.losses import DistinctnessLoss, ForegroundContrastLoss
+from cuvis_ai.node.losses import (
+    CrossEntropyLoss,
+    DiceLoss,
+    DistinctnessLoss,
+    ForegroundContrastLoss,
+)
 from cuvis_ai.node.mask_ops import (
     ClassMapRobustifier,
     LabelOffset,
@@ -163,10 +168,12 @@ __all__ = [
     "ClassMapToRGB",
     "FastRGBSelector",
     "ConcreteChannelMixer",
+    "CrossEntropyLoss",
     "CubeRGBVisualizer",
     "DetectionCocoJsonNode",
     "DetectionJsonReader",
     "DecisionToMask",
+    "DiceLoss",
     "DisplayNormalizer",
     "DistinctnessLoss",
     "FixedWavelengthSelector",

--- a/cuvis_ai/node/losses.py
+++ b/cuvis_ai/node/losses.py
@@ -899,8 +899,10 @@ def _soft_dice_loss(
 
     ``logits_bchw`` is ``[B, K, H, W]`` and ``targets_bhw`` is an integer
     ``[B, H, W]`` label map. ``K == 1`` uses a sigmoid/binary formulation;
-    ``K > 1`` uses softmax over one-hot targets. Pixels equal to ``ignore_index``
-    are excluded from both the prediction and the target; when
+    ``K > 1`` uses softmax over one-hot targets. Dice is accumulated per class
+    over the whole batch (batch Dice), not averaged per sample. Pixels equal to
+    ``ignore_index`` are excluded from both the prediction and the target; any
+    other multiclass target outside ``[0, K)`` raises. When
     ``include_background`` is False, class 0 is dropped from the per-class mean
     (multiclass only). Returns ``1 - mean(dice)``.
     """
@@ -914,7 +916,7 @@ def _soft_dice_loss(
         safe = targets_bhw
         if ignore_index is not None:
             safe = targets_bhw.masked_fill(targets_bhw == ignore_index, 0)
-        onehot = F.one_hot(safe.clamp(0, num_classes - 1), num_classes)
+        onehot = F.one_hot(safe, num_classes)
         onehot = onehot.permute(0, 3, 1, 2).to(probs.dtype)
         cls = slice(0 if include_background else 1, num_classes)
 
@@ -940,7 +942,7 @@ _SEG_LOGITS_SPEC = PortSpec(
 _SEG_TARGETS_SPEC = PortSpec(
     dtype=torch.int32,
     shape=(-1, -1, -1),
-    description="Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)",
+    description="Integer class-index mask [B, H, W]; cast to int64 internally",
 )
 _SEG_LOSS_OUT_SPEC = PortSpec(dtype=torch.float32, shape=(), description="Scalar loss value")
 
@@ -949,9 +951,12 @@ class DiceLoss(LossNode):
     """Soft Dice loss over dense segmentation logits.
 
     Consumes BHWC per-pixel class logits (last axis = classes; the class count
-    is inferred at runtime — ``K == 1`` is treated as sigmoid binary, ``K > 1``
+    is inferred at runtime, ``K == 1`` is treated as sigmoid binary, ``K > 1``
     as softmax multiclass over one-hot targets) plus an integer class-index
-    mask, and emits a scalar loss ``1 - mean(dice)``.
+    mask, and emits a scalar loss ``1 - mean(dice)``. Dice is accumulated per
+    class over the whole batch (nnU-Net-style batch Dice) rather than averaged
+    per sample. Multiclass targets outside ``[0, K)`` that are not
+    ``ignore_index`` raise.
 
     Parameters
     ----------
@@ -1047,6 +1052,13 @@ class CrossEntropyLoss(LossNode):
     ignore_index : int, optional
         Target value excluded from the loss (default: -100, PyTorch's default)
 
+    Raises
+    ------
+    ValueError
+        If the logits carry a single class channel (``K == 1``). Softmax over
+        one logit is constant 1, so the loss would be identically zero; use
+        ``DiceLoss`` or ``AnomalyBCEWithLogits`` for single-logit binary heads.
+
     Examples
     --------
     >>> ce = CrossEntropyLoss(class_weights=[0.1, 1.0])
@@ -1096,6 +1108,12 @@ class CrossEntropyLoss(LossNode):
         dict[str, Tensor]
             Dictionary with "loss" key containing the scalar cross-entropy
         """
+        if logits.shape[-1] == 1:
+            raise ValueError(
+                "CrossEntropyLoss needs multiclass logits [B, H, W, K>=2]; softmax over a "
+                "single logit is constant, so the loss would always be zero. Use DiceLoss or "
+                "AnomalyBCEWithLogits for single-logit binary heads."
+            )
         logits_bchw, targets_bhw = _to_bchw_targets(logits, targets)
         buf = getattr(self, "_class_weights", None)
         weights = buf.to(logits_bchw.dtype) if buf is not None else None

--- a/cuvis_ai/node/losses.py
+++ b/cuvis_ai/node/losses.py
@@ -875,10 +875,242 @@ class ForegroundContrastLoss(LossNode):
         return {"loss": loss}
 
 
+def _to_bchw_targets(logits: Tensor, targets: Tensor) -> tuple[Tensor, Tensor]:
+    """Convert BHWC logits to NCHW and squeeze a trailing target channel.
+
+    ``logits`` ``[B, H, W, K]`` -> ``[B, K, H, W]``; ``targets`` ``[B, H, W, 1]``
+    or ``[B, H, W]`` -> long ``[B, H, W]``.
+    """
+    logits = logits.permute(0, 3, 1, 2)
+    if targets.dim() == 4 and targets.shape[-1] == 1:
+        targets = targets[..., 0]
+    return logits, targets.long()
+
+
+def _soft_dice_loss(
+    logits_bchw: Tensor,
+    targets_bhw: Tensor,
+    *,
+    ignore_index: int | None = None,
+    include_background: bool = True,
+    eps: float = 1e-6,
+) -> Tensor:
+    """Soft Dice loss for binary (``K == 1``) or multiclass (``K > 1``) logits.
+
+    ``logits_bchw`` is ``[B, K, H, W]`` and ``targets_bhw`` is an integer
+    ``[B, H, W]`` label map. ``K == 1`` uses a sigmoid/binary formulation;
+    ``K > 1`` uses softmax over one-hot targets. Pixels equal to ``ignore_index``
+    are excluded from both the prediction and the target; when
+    ``include_background`` is False, class 0 is dropped from the per-class mean
+    (multiclass only). Returns ``1 - mean(dice)``.
+    """
+    num_classes = logits_bchw.shape[1]
+    if num_classes == 1:
+        probs = torch.sigmoid(logits_bchw)
+        onehot = (targets_bhw == 1).unsqueeze(1).to(probs.dtype)
+        cls = slice(0, 1)
+    else:
+        probs = torch.softmax(logits_bchw, dim=1)
+        safe = targets_bhw
+        if ignore_index is not None:
+            safe = targets_bhw.masked_fill(targets_bhw == ignore_index, 0)
+        onehot = F.one_hot(safe.clamp(0, num_classes - 1), num_classes)
+        onehot = onehot.permute(0, 3, 1, 2).to(probs.dtype)
+        cls = slice(0 if include_background else 1, num_classes)
+
+    if ignore_index is not None:
+        valid = (targets_bhw != ignore_index).unsqueeze(1).to(probs.dtype)
+        probs = probs * valid
+        onehot = onehot * valid
+
+    p = probs[:, cls]
+    g = onehot[:, cls]
+    dims = (0, 2, 3)  # sum over batch and spatial dims -> one Dice per class
+    inter = (p * g).sum(dims)
+    denom = p.sum(dims) + g.sum(dims)
+    dice = (2.0 * inter + eps) / (denom + eps)
+    return 1.0 - dice.mean()
+
+
+_SEG_LOGITS_SPEC = PortSpec(
+    dtype=torch.float32,
+    shape=(-1, -1, -1, -1),
+    description="Per-pixel class logits [B, H, W, num_classes]",
+)
+_SEG_TARGETS_SPEC = PortSpec(
+    dtype=torch.int32,
+    shape=(-1, -1, -1),
+    description="Integer class-index mask [B, H, W] (cast to int64 internally; trailing [.,1] ok)",
+)
+_SEG_LOSS_OUT_SPEC = PortSpec(dtype=torch.float32, shape=(), description="Scalar loss value")
+
+
+class DiceLoss(LossNode):
+    """Soft Dice loss over dense segmentation logits.
+
+    Consumes BHWC per-pixel class logits (last axis = classes; the class count
+    is inferred at runtime — ``K == 1`` is treated as sigmoid binary, ``K > 1``
+    as softmax multiclass over one-hot targets) plus an integer class-index
+    mask, and emits a scalar loss ``1 - mean(dice)``.
+
+    Parameters
+    ----------
+    weight : float, optional
+        Scalar multiplier applied to the loss, for combining several losses
+        (default: 1.0)
+    ignore_index : int or None, optional
+        Target value excluded from both prediction and target, or ``None`` to
+        use every pixel (default: None)
+    include_background : bool, optional
+        Whether class 0 contributes to the per-class Dice mean; multiclass
+        only (default: True). Disabling it is the standard choice for heavily
+        imbalanced segmentation, where the background Dice term is saturated
+        and dilutes the foreground signal.
+    eps : float, optional
+        Smoothing constant for the Dice ratio (default: 1e-6)
+
+    Examples
+    --------
+    >>> dice = DiceLoss(weight=1.0, include_background=False)
+    >>> loss = dice.forward(logits=logits_bhwk, targets=mask_bhw)["loss"]
+    """
+
+    _category = NodeCategory.LOSS
+    _tags = frozenset(
+        {NodeTag.TRAINING, NodeTag.DIFFERENTIABLE, NodeTag.TORCH, NodeTag.SEGMENTATION}
+    )
+
+    INPUT_SPECS = {"logits": _SEG_LOGITS_SPEC, "targets": _SEG_TARGETS_SPEC}
+    OUTPUT_SPECS = {"loss": _SEG_LOSS_OUT_SPEC}
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        ignore_index: int | None = None,
+        include_background: bool = True,
+        eps: float = 1e-6,
+        **kwargs,
+    ) -> None:
+        self.weight = float(weight)
+        self.ignore_index = ignore_index
+        self.include_background = bool(include_background)
+        self.eps = float(eps)
+        super().__init__(
+            weight=self.weight,
+            ignore_index=ignore_index,
+            include_background=self.include_background,
+            eps=self.eps,
+            **kwargs,
+        )
+
+    def forward(self, logits: Tensor, targets: Tensor, **_: Any) -> dict[str, Tensor]:
+        """Compute the weighted soft Dice loss from BHWC logits and a mask.
+
+        Parameters
+        ----------
+        logits : Tensor
+            Per-pixel class logits [B, H, W, K]
+        targets : Tensor
+            Integer class-index mask [B, H, W] (a trailing singleton channel
+            is squeezed)
+
+        Returns
+        -------
+        dict[str, Tensor]
+            Dictionary with "loss" key containing the scalar Dice loss
+        """
+        logits_bchw, targets_bhw = _to_bchw_targets(logits, targets)
+        loss = _soft_dice_loss(
+            logits_bchw,
+            targets_bhw,
+            ignore_index=self.ignore_index,
+            include_background=self.include_background,
+            eps=self.eps,
+        )
+        return {"loss": self.weight * loss}
+
+
+class CrossEntropyLoss(LossNode):
+    """Pixel-wise cross-entropy over dense segmentation logits (``K >= 2``).
+
+    Consumes BHWC per-pixel class logits plus an integer class-index mask and
+    emits a scalar loss. The class count is the logits' last axis; no
+    ``num_classes`` hyperparameter is needed.
+
+    Parameters
+    ----------
+    weight : float, optional
+        Scalar multiplier applied to the loss (default: 1.0)
+    class_weights : list of float or None, optional
+        Per-class rescaling passed to ``F.cross_entropy``; helps with strong
+        class imbalance such as small foreground objects (default: None)
+    ignore_index : int, optional
+        Target value excluded from the loss (default: -100, PyTorch's default)
+
+    Examples
+    --------
+    >>> ce = CrossEntropyLoss(class_weights=[0.1, 1.0])
+    >>> loss = ce.forward(logits=logits_bhwk, targets=mask_bhw)["loss"]
+    """
+
+    _category = NodeCategory.LOSS
+    _tags = frozenset(
+        {NodeTag.TRAINING, NodeTag.DIFFERENTIABLE, NodeTag.TORCH, NodeTag.SEGMENTATION}
+    )
+
+    INPUT_SPECS = {"logits": _SEG_LOGITS_SPEC, "targets": _SEG_TARGETS_SPEC}
+    OUTPUT_SPECS = {"loss": _SEG_LOSS_OUT_SPEC}
+
+    def __init__(
+        self,
+        weight: float = 1.0,
+        class_weights: list[float] | None = None,
+        ignore_index: int = -100,
+        **kwargs,
+    ) -> None:
+        self.weight = float(weight)
+        self.class_weights = class_weights
+        self.ignore_index = int(ignore_index)
+        super().__init__(
+            weight=self.weight,
+            class_weights=class_weights,
+            ignore_index=self.ignore_index,
+            **kwargs,
+        )
+        if class_weights is not None:
+            self.register_buffer("_class_weights", torch.tensor(class_weights, dtype=torch.float32))
+
+    def forward(self, logits: Tensor, targets: Tensor, **_: Any) -> dict[str, Tensor]:
+        """Compute the weighted cross-entropy from BHWC logits and a mask.
+
+        Parameters
+        ----------
+        logits : Tensor
+            Per-pixel class logits [B, H, W, K]
+        targets : Tensor
+            Integer class-index mask [B, H, W] (a trailing singleton channel
+            is squeezed)
+
+        Returns
+        -------
+        dict[str, Tensor]
+            Dictionary with "loss" key containing the scalar cross-entropy
+        """
+        logits_bchw, targets_bhw = _to_bchw_targets(logits, targets)
+        buf = getattr(self, "_class_weights", None)
+        weights = buf.to(logits_bchw.dtype) if buf is not None else None
+        loss = F.cross_entropy(
+            logits_bchw, targets_bhw, weight=weights, ignore_index=self.ignore_index
+        )
+        return {"loss": self.weight * loss}
+
+
 __all__ = [
     "LossNode",
     "OrthogonalityLoss",
     "AnomalyBCEWithLogits",
+    "CrossEntropyLoss",
+    "DiceLoss",
     "MSEReconstructionLoss",
     "SelectorEntropyRegularizer",
     "SelectorDiversityRegularizer",

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -6,6 +6,8 @@ import torch.nn.functional as F
 
 from cuvis_ai.node.losses import (
     AnomalyBCEWithLogits,
+    CrossEntropyLoss,
+    DiceLoss,
     DistinctnessLoss,
     MSEReconstructionLoss,
     OrthogonalityLoss,
@@ -362,12 +364,159 @@ class TestLossNodeProtocol:
             AnomalyBCEWithLogits(),
             MSEReconstructionLoss(),
             DistinctnessLoss(),
+            DiceLoss(),
+            CrossEntropyLoss(),
         ]
 
         for loss_node in loss_classes:
             assert hasattr(loss_node, "forward")
             assert callable(loss_node.forward)
             assert "loss" in loss_node.OUTPUT_SPECS
+
+
+def _seg_batch(num_classes: int = 2, seed: int = 0) -> tuple[torch.Tensor, torch.Tensor]:
+    """Small BHWC logits + integer mask pair for the segmentation losses."""
+    g = torch.Generator().manual_seed(seed)
+    logits = torch.randn(2, 8, 8, num_classes, generator=g, requires_grad=True)
+    targets = torch.randint(0, num_classes, (2, 8, 8), generator=g, dtype=torch.int32)
+    return logits, targets
+
+
+class TestDiceLoss:
+    """Tests for DiceLoss."""
+
+    def test_initialization(self):
+        """Test DiceLoss initialization and hparams."""
+        node = DiceLoss(weight=2.0, ignore_index=255, include_background=False, eps=1e-5)
+        assert node.weight == 2.0
+        assert node.ignore_index == 255
+        assert node.include_background is False
+        assert node.eps == 1e-5
+        assert isinstance(node, Node)
+
+    def test_matches_manual_soft_dice(self):
+        """Vectorized node output equals a hand-computed soft Dice."""
+        logits, targets = _seg_batch(num_classes=3)
+        out = DiceLoss(weight=1.0).forward(logits=logits, targets=targets)["loss"]
+
+        probs = torch.softmax(logits.permute(0, 3, 1, 2), dim=1)
+        onehot = F.one_hot(targets.long(), 3).permute(0, 3, 1, 2).to(probs.dtype)
+        inter = (probs * onehot).sum((0, 2, 3))
+        denom = probs.sum((0, 2, 3)) + onehot.sum((0, 2, 3))
+        expected = 1.0 - ((2.0 * inter + 1e-6) / (denom + 1e-6)).mean()
+        assert torch.allclose(out, expected, atol=1e-6)
+
+    def test_perfect_prediction_near_zero(self):
+        """Extreme logits matching the targets drive the loss toward zero."""
+        _, targets = _seg_batch(num_classes=2)
+        logits = F.one_hot(targets.long(), 2).float() * 100.0  # [B,H,W,K]
+        loss = DiceLoss().forward(logits=logits, targets=targets)["loss"]
+        assert loss.item() < 1e-4
+
+    def test_weight_scaling(self):
+        """Doubling weight doubles the loss."""
+        logits, targets = _seg_batch()
+        l1 = DiceLoss(weight=1.0).forward(logits=logits, targets=targets)["loss"]
+        l2 = DiceLoss(weight=2.0).forward(logits=logits, targets=targets)["loss"]
+        assert torch.allclose(2.0 * l1, l2, atol=1e-7)
+
+    def test_gradient_flows(self):
+        """Loss backpropagates to the logits."""
+        logits, targets = _seg_batch()
+        loss = DiceLoss().forward(logits=logits, targets=targets)["loss"]
+        loss.backward()
+        assert logits.grad is not None
+        assert torch.isfinite(logits.grad).all()
+
+    def test_include_background_changes_loss(self):
+        """Dropping class 0 from the mean changes the multiclass loss."""
+        logits, targets = _seg_batch(num_classes=3)
+        with_bg = DiceLoss(include_background=True).forward(logits=logits, targets=targets)
+        without_bg = DiceLoss(include_background=False).forward(logits=logits, targets=targets)
+        assert not torch.allclose(with_bg["loss"], without_bg["loss"])
+
+    def test_ignore_index_excludes_pixels(self):
+        """Marking every mismatching pixel ignored leaves a near-perfect Dice."""
+        _, targets = _seg_batch(num_classes=2)
+        logits = F.one_hot(targets.long(), 2).float() * 100.0
+        corrupted = targets.clone()
+        corrupted[:, :4] = 1 - corrupted[:, :4]  # break the top half...
+        corrupted_marked = corrupted.clone()
+        corrupted_marked[:, :4] = 255  # ...then exclude it
+        broken = DiceLoss().forward(logits=logits, targets=corrupted)["loss"]
+        ignored = DiceLoss(ignore_index=255).forward(logits=logits, targets=corrupted_marked)
+        assert broken.item() > 0.1
+        assert ignored["loss"].item() < 1e-3
+
+    def test_binary_single_logit_head(self):
+        """K == 1 logits use the sigmoid/binary formulation."""
+        g = torch.Generator().manual_seed(1)
+        targets = torch.randint(0, 2, (2, 8, 8), generator=g, dtype=torch.int32)
+        logits = (targets.float() * 200.0 - 100.0).unsqueeze(-1)  # [B,H,W,1]
+        loss = DiceLoss().forward(logits=logits, targets=targets)["loss"]
+        assert loss.item() < 1e-4
+
+
+class TestCrossEntropyLoss:
+    """Tests for CrossEntropyLoss."""
+
+    def test_initialization(self):
+        """Test CrossEntropyLoss initialization and hparams."""
+        node = CrossEntropyLoss(weight=0.5, class_weights=[0.1, 1.0], ignore_index=7)
+        assert node.weight == 0.5
+        assert node.class_weights == [0.1, 1.0]
+        assert node.ignore_index == 7
+        assert isinstance(node, Node)
+
+    def test_matches_functional_cross_entropy(self):
+        """Node output equals F.cross_entropy on permuted logits."""
+        logits, targets = _seg_batch(num_classes=4)
+        out = CrossEntropyLoss().forward(logits=logits, targets=targets)["loss"]
+        expected = F.cross_entropy(logits.permute(0, 3, 1, 2), targets.long())
+        assert torch.allclose(out, expected, atol=1e-6)
+
+    def test_class_weights_applied(self):
+        """Per-class weights change the loss and match F.cross_entropy."""
+        logits, targets = _seg_batch(num_classes=2)
+        cw = [0.1, 10.0]
+        out = CrossEntropyLoss(class_weights=cw).forward(logits=logits, targets=targets)["loss"]
+        expected = F.cross_entropy(
+            logits.permute(0, 3, 1, 2), targets.long(), weight=torch.tensor(cw)
+        )
+        assert torch.allclose(out, expected, atol=1e-6)
+        plain = CrossEntropyLoss().forward(logits=logits, targets=targets)["loss"]
+        assert not torch.allclose(out, plain)
+
+    def test_ignore_index_matches_functional(self):
+        """ignore_index excludes pixels exactly as F.cross_entropy does."""
+        logits, targets = _seg_batch(num_classes=3)
+        marked = targets.clone()
+        marked[:, :2] = 255
+        out = CrossEntropyLoss(ignore_index=255).forward(logits=logits, targets=marked)["loss"]
+        expected = F.cross_entropy(logits.permute(0, 3, 1, 2), marked.long(), ignore_index=255)
+        assert torch.allclose(out, expected, atol=1e-6)
+
+    def test_weight_scaling(self):
+        """Doubling weight doubles the loss."""
+        logits, targets = _seg_batch()
+        l1 = CrossEntropyLoss(weight=1.0).forward(logits=logits, targets=targets)["loss"]
+        l2 = CrossEntropyLoss(weight=2.0).forward(logits=logits, targets=targets)["loss"]
+        assert torch.allclose(2.0 * l1, l2, atol=1e-7)
+
+    def test_gradient_flows(self):
+        """Loss backpropagates to the logits."""
+        logits, targets = _seg_batch()
+        loss = CrossEntropyLoss().forward(logits=logits, targets=targets)["loss"]
+        loss.backward()
+        assert logits.grad is not None
+        assert torch.isfinite(logits.grad).all()
+
+    def test_trailing_target_channel_squeezed(self):
+        """A [B, H, W, 1] target is accepted and matches the [B, H, W] result."""
+        logits, targets = _seg_batch()
+        a = CrossEntropyLoss().forward(logits=logits, targets=targets)["loss"]
+        b = CrossEntropyLoss().forward(logits=logits, targets=targets.unsqueeze(-1))["loss"]
+        assert torch.allclose(a, b)
 
 
 if __name__ == "__main__":

--- a/tests/training/test_losses.py
+++ b/tests/training/test_losses.py
@@ -456,6 +456,28 @@ class TestDiceLoss:
         loss = DiceLoss().forward(logits=logits, targets=targets)["loss"]
         assert loss.item() < 1e-4
 
+    def test_binary_ignore_index_excludes_pixels(self):
+        """The K == 1 sigmoid path honors ignore_index too."""
+        g = torch.Generator().manual_seed(3)
+        targets = torch.randint(0, 2, (2, 8, 8), generator=g, dtype=torch.int32)
+        logits = (targets.float() * 200.0 - 100.0).unsqueeze(-1)  # [B,H,W,1]
+        corrupted = targets.clone()
+        corrupted[:, :4] = 1 - corrupted[:, :4]
+        corrupted_marked = corrupted.clone()
+        corrupted_marked[:, :4] = 255
+        broken = DiceLoss().forward(logits=logits, targets=corrupted)["loss"]
+        ignored = DiceLoss(ignore_index=255).forward(logits=logits, targets=corrupted_marked)
+        assert broken.item() > 0.1
+        assert ignored["loss"].item() < 1e-3
+
+    def test_out_of_range_target_raises(self):
+        """A multiclass target outside [0, K) that is not ignore_index raises."""
+        logits, targets = _seg_batch(num_classes=3)
+        bad = targets.clone()
+        bad[0, 0, 0] = 3
+        with pytest.raises(RuntimeError):
+            DiceLoss().forward(logits=logits, targets=bad)
+
 
 class TestCrossEntropyLoss:
     """Tests for CrossEntropyLoss."""
@@ -517,6 +539,14 @@ class TestCrossEntropyLoss:
         a = CrossEntropyLoss().forward(logits=logits, targets=targets)["loss"]
         b = CrossEntropyLoss().forward(logits=logits, targets=targets.unsqueeze(-1))["loss"]
         assert torch.allclose(a, b)
+
+    def test_single_logit_head_raises(self):
+        """K == 1 logits are rejected instead of silently yielding zero loss."""
+        g = torch.Generator().manual_seed(2)
+        targets = torch.randint(0, 2, (2, 8, 8), generator=g, dtype=torch.int32)
+        logits = torch.randn(2, 8, 8, 1, generator=g)
+        with pytest.raises(ValueError, match="single logit"):
+            CrossEntropyLoss().forward(logits=logits, targets=targets)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds the two dense-segmentation losses the builtin library lacked (IoULoss is binary-only): **DiceLoss** and **CrossEntropyLoss**, both consuming BHWC per-pixel class logits + an integer class-index mask and emitting a scalar loss.

## Design
- Class count is inferred from the logits' last axis — no `num_classes` hparam. `K=1` runs the sigmoid/binary Dice formulation, `K>1` softmax over one-hot targets.
- `DiceLoss`: `weight` / `ignore_index` / `include_background` / `eps`. Excluding background from the per-class mean is the standard nnU-Net-style choice for heavily imbalanced segmentation.
- `CrossEntropyLoss`: `weight` / `class_weights` (registered buffer, cast to logits dtype) / `ignore_index` (-100, PyTorch default).
- Both subclass the existing `LossNode` (train/val/test only) and follow the `IoULoss` pattern for the SEGMENTATION tag; registered in `configs/plugins/cuvis_ai_builtin.yaml`.
- These are the first builtin losses with multiclass `[B,H,W,K]` logits; existing ones are binary `[B,H,W,1]`.

## Provenance
Battle-tested in the cuvis-ai-unet plugin on the lentils foreign-object segmentation task (fg-IoU 0.79 champion). The plugin keeps its copies until this ships, then drops them in its next minor (pipeline configs reference fully-qualified class paths, and NodeRegistry resolves duplicates last-wins by simple name, so coexistence is safe).

## Tests
`tests/training/test_losses.py`: reference equivalence (hand-computed soft Dice; `F.cross_entropy` on permuted logits), weight scaling, gradient flow, `include_background`, `ignore_index`, single-logit binary head, trailing target channel squeeze — 36 total in the file, all green. `ruff` + `ruff format` clean, `interrogate` 96.8% (≥95 gate).