### PR TITLE
Dinomaly CIR preset for CuvisNEXT training, sam3 v0.3.0 pin, manifest package_name fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## [Unreleased]
+## 0.11.4 - 2026-07-28
 
+- Added the Dinomaly CIR anomaly-detection preset: `configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml` (AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 860/670/560 nm NIR/R/G false-color → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and per-epoch score heatmaps into TensorBoardMonitorNode). Sibling of the 0.11.2 `dinomaly_rgb` preset for SWIR-leaning scenes where CIR separates anomalies better than visible RGB.
+- Added the matching flat trainrun preset `configs/trainrun/dinomaly_cir_cuvisnext.yaml` for the gRPC `RestoreTrainRun` path (gradient: adamw lr 2e-3, checkpoint on `metrics_anomaly/iou` max; `cu3s` data block with `frames: measurements` + `recursive: true` and empty `data_dir` / `splits.splits_path` the caller fills per run).
+- Bumped the sam3 plugin manifest pin v0.2.1 -> v0.3.0: process-level shared ViT+text backbone registry, so all SAM3 nodes in one child process share one resident backbone and annotate↔propagate pipeline switches stay warm.
 - Bumped the cuvis-ai-dataloader plugin manifest pin v0.4.0 -> v0.5.0: both `cu3s_multi` and `npz_multi` now speak one `universe.csv` vocabulary (shared `source, index` selector keys), `cu3s` folder mode gains per-measurement enumeration for GUI-authored `splits.json`, and the manifest exposes the `npz_multi` capability. Documented the unified vocabulary across the data-splits / get-started / workflow docs.
+- Added the missing `package_name` to the deepeiou, dinomaly, and trackeval plugin manifests: for git-pinned manifests the child-env composer needs the real installable name (`cuvis-ai-<x>` vs the logical `<x>`) for uv's metadata check to pass.
 
 ## 0.11.3 - 2026-07-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ plugin (local checkout only, not published or referenced from public docs);
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **cuvis-ai** (8345 symbols, 13291 relationships, 164 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **cuvis-ai** (8349 symbols, 13294 relationships, 164 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
@@ -1,0 +1,112 @@
+metadata:
+  name: dinomaly_cir
+  description: "Dinomaly anomaly detection on a fixed-wavelength CIR (color-infrared)
+    false-color projection (860/670/560 nm = NIR/R/G): AnomalyDataNode → MinMaxNormalizer
+    → FixedWavelengthSelector → DinomalyDetector, with quantile decider, pixel/image
+    metrics, AUROC, and per-epoch score heatmaps logged to TensorBoard."
+  created: ''
+  tags:
+  - gradient
+  - dinomaly
+  - anomaly
+  - cir
+  author: cuvis.ai
+  cuvis_ai_version: 0.11.1
+plugins:
+- dinomaly
+- cuvis_ai_builtin
+nodes:
+- name: anomaly_data
+  class_name: cuvis_ai.node.data.AnomalyDataNode
+  hparams:
+    normal_class_ids:
+    - 0
+- name: MinMaxNormalizer
+  class_name: cuvis_ai.node.normalization.MinMaxNormalizer
+  hparams:
+    eps: 1.0e-06
+    use_running_stats: true
+    max_initialization_frames: 20
+- name: cir_selector
+  class_name: cuvis_ai.node.channel_selector.FixedWavelengthSelector
+  hparams:
+    target_wavelengths:
+    - 860.0
+    - 670.0
+    - 560.0
+    normalize_output: true
+    norm_mode: running
+    apply_gamma: true
+    freeze_running_bounds_after_frames: 20
+    running_warmup_frames: 10
+- name: dinomaly_detector
+  class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
+  hparams:
+    encoder_name: dinov2reg_vit_base_14
+    bottleneck_dropout: 0.2
+    decoder_depth: 8
+    image_size: 448
+    crop_size: 448
+    use_center_crop: false
+    input_channels: 3
+- name: dinomaly_train_loss
+  class_name: cuvis_ai_dinomaly.node.dinomaly_train_loss_bridge.DinomalyTrainLossBridge
+  hparams:
+    weight: 1.0
+- name: decider
+  class_name: cuvis_ai.node.deciders.binary_decider.QuantileBinaryDecider
+  hparams:
+    quantile: 0.995
+- name: metrics_anomaly
+  class_name: cuvis_ai.node.metrics.AnomalyDetectionMetrics
+  hparams: {}
+- name: metrics_auroc
+  class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
+  hparams:
+    thresholds: 200
+- name: score_heatmap
+  class_name: cuvis_ai.node.anomaly_visualization.ScoreHeatmapVisualizer
+  hparams:
+    normalize_scores: true
+    cmap: inferno
+    up_to: 3
+- name: TensorBoardMonitorNode
+  class_name: cuvis_ai.node.monitor.TensorBoardMonitorNode
+  hparams:
+    output_dir: outputs/dinomaly_cir/tensorboard
+    run_name: dinomaly_cir
+    comment: ''
+    flush_secs: 120
+connections:
+- source: anomaly_data.outputs.cube
+  target: MinMaxNormalizer.inputs.data
+- source: anomaly_data.outputs.wavelengths
+  target: cir_selector.inputs.wavelengths
+- source: anomaly_data.outputs.mask
+  target: metrics_anomaly.inputs.targets
+- source: anomaly_data.outputs.mask
+  target: metrics_auroc.inputs.targets
+- source: MinMaxNormalizer.outputs.normalized
+  target: cir_selector.inputs.cube
+- source: cir_selector.outputs.rgb_image
+  target: dinomaly_detector.inputs.rgb_image
+- source: dinomaly_detector.outputs.training_loss
+  target: dinomaly_train_loss.inputs.raw_loss
+- source: dinomaly_detector.outputs.scores
+  target: decider.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_anomaly.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_auroc.inputs.scores
+- source: dinomaly_detector.outputs.anomaly_score
+  target: metrics_auroc.inputs.anomaly_score
+- source: dinomaly_detector.outputs.scores
+  target: score_heatmap.inputs.scores
+- source: decider.outputs.decisions
+  target: metrics_anomaly.inputs.decisions
+- source: metrics_anomaly.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: metrics_auroc.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: score_heatmap.outputs.artifacts
+  target: TensorBoardMonitorNode.inputs.artifacts

--- a/cuvis_ai/configs/plugins/deepeiou.yaml
+++ b/cuvis_ai/configs/plugins/deepeiou.yaml
@@ -8,6 +8,7 @@ name: deepeiou
 # path: "../../../../cuvis-ai-deepeiou/deepeiou-init"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-deepeiou.git"
 tag: "v0.2.1"
+package_name: "cuvis-ai-deepeiou"
 capabilities:
 - class_name: cuvis_ai_deepeiou.node.DeepEIoUTrack
   category: transform

--- a/cuvis_ai/configs/plugins/dinomaly.yaml
+++ b/cuvis_ai/configs/plugins/dinomaly.yaml
@@ -9,6 +9,7 @@ name: dinomaly
 # path: "../../../cuvis-ai-dinomaly"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly.git"
 tag: "v0.5.0"
+package_name: "cuvis-ai-dinomaly"
 capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
   category: model

--- a/cuvis_ai/configs/plugins/rtsam2.yaml
+++ b/cuvis_ai/configs/plugins/rtsam2.yaml
@@ -8,7 +8,7 @@ name: rtsam2
 # Real-time SAM2 / EfficientTAM streaming tracking plugin.
 #
 # For local development against a checkout, comment the repo/tag pin and use:
-# path: "D:/code-repos/cuvis-ai-rtsam2"
+# path: "D:/code-repos/cuvis-ai-rtsam2/cuvis-ai-rtsam2"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-rtsam2.git"
 tag: "v0.2.0"
 package_name: "cuvis-ai-rtsam2"

--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.2.1"  # schemas 0.8.0 / core 0.11.0 floors + click/pillow security bumps
+tag: "v0.3.0"  # process-wide shared ViT backbone for fast SAM3 pipeline switching
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation

--- a/cuvis_ai/configs/plugins/trackeval.yaml
+++ b/cuvis_ai/configs/plugins/trackeval.yaml
@@ -8,6 +8,7 @@ name: trackeval
 # TrackEval-based tracking metric nodes for HOTA, CLEAR, and Identity evaluation
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-trackeval.git"
 tag: "v0.1.4"
+package_name: "cuvis-ai-trackeval"
 capabilities:
 - class_name: cuvis_ai_trackeval.node.HOTAMetricNode
   category: metric

--- a/cuvis_ai/configs/trainrun/dinomaly_cir_cuvisnext.yaml
+++ b/cuvis_ai/configs/trainrun/dinomaly_cir_cuvisnext.yaml
@@ -1,0 +1,63 @@
+# Flat serialized TrainRunConfig (no Hydra defaults): consumed verbatim by the
+# gRPC RestoreTrainRun path, which is how CuvisNEXT starts a training run. The
+# GUI fills the two empty data fields (data_dir + splits.splits_path) and its
+# user edits (epochs, batch size, optimizer, output_dir) via SetTrainRunConfig.
+name: dinomaly_cir_cuvisnext
+
+# Pipeline reference, resolved relative to this trainrun's directory.
+pipeline: ../pipeline/anomaly/dinomaly/dinomaly_cir.yaml
+
+data:
+  data_module: cu3s
+  batch_size: 1
+  # Windows spawn safety with open SDK handles is unverified; keep in-process.
+  num_workers: 0
+  splits:
+    # Absolute path to a frozen splits.json (file_indices selectors); authored
+    # and filled in by the caller. Training stages refuse to run without it.
+    splits_path: ''
+  params:
+    # Absolute path of the cu3s dataset folder; filled in by the caller.
+    data_dir: ''
+    # One sample per measurement per file, enumerated with canonical absolute
+    # sources — the contract externally authored splits.json are written against.
+    frames: measurements
+    recursive: true
+    processing_mode: Reflectance
+
+training:
+  seed: 42
+  max_epochs: 60
+  accelerator: auto
+  devices: 1
+  default_root_dir: outputs/dinomaly_cir
+  precision: 32-true
+  enable_progress_bar: false
+  enable_checkpointing: true
+  log_every_n_steps: 10
+  check_val_every_n_epoch: 1
+  gradient_clip_val: 0.1
+  optimizer:
+    name: adamw
+    lr: 0.002
+    weight_decay: 0.0001
+    betas:
+    - 0.9
+    - 0.999
+  callbacks:
+    checkpoint:
+      dirpath: outputs/dinomaly_cir/checkpoints
+      monitor: metrics_anomaly/iou
+      mode: max
+      save_top_k: 1
+      save_last: true
+      filename: '{epoch:02d}'
+
+loss_nodes:
+- dinomaly_train_loss
+metric_nodes:
+- metrics_anomaly
+- metrics_auroc
+unfreeze_nodes:
+- dinomaly_detector
+output_dir: outputs/dinomaly_cir


### PR DESCRIPTION
## What

Release batch **0.11.4** for the CuvisNEXT anomaly-detection training flow:

- **Dinomaly CIR preset**: `configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml` — AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 860/670/560 nm (NIR/R/G false color) → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and per-epoch score heatmaps into TensorBoard. Sibling of the 0.11.2 `dinomaly_rgb` preset for scenes where CIR separates anomalies better than visible RGB.
- **Matching flat trainrun preset** `configs/trainrun/dinomaly_cir_cuvisnext.yaml` for the gRPC `RestoreTrainRun` path (gradient: adamw lr 2e-3, checkpoint on `metrics_anomaly/iou` max; `cu3s` data block with `frames: measurements` + `recursive: true`, empty `data_dir` / `splits.splits_path` filled by the caller per run).
- **sam3 manifest pin v0.2.1 → v0.3.0**: process-level shared ViT+text backbone registry — all SAM3 nodes in one child process share one resident backbone, keeping annotate↔propagate pipeline switches warm.
- **`package_name` added to the deepeiou / dinomaly / trackeval manifests** (git-pinned manifests need the real installable name for the child-env composer's uv metadata check), plus an rtsam2 dev-path comment fix.
- Carries the cuvis-ai-dataloader manifest pin v0.4.0 → v0.5.0 (`universe.csv` vocabulary, per-measurement cu3s enumeration, `npz_multi` capability) already on `main` but not yet released.

CHANGELOG stamped `0.11.4 - 2026-07-28`.

> Supersedes this PR's original scope — the Dinomaly RGB / AdaCLIP presets it was opened for shipped in 0.11.2.

## Why

CuvisNEXT's training wizard offers packaged presets; the CIR variant is the second anomaly-detection preset it exposes. The sam3 0.3.0 pin is the cuvis-ai-side half of the fast annotate↔propagate switch shipped in the app.

## Verified

- Full local pytest suite via the pre-push hook (ruff, interrogate ≥95, `pytest -m "not slow and not gpu"`).
- CI on this branch.
