### PR TITLE
release: cuvis-ai 0.11.2 (dinomaly v0.5.0 pin + RGB/AdaCLIP presets)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,15 @@ jobs:
           # PYSEC-2026-3447: setuptools sdist MANIFEST.in glob bypass (macOS NFD/NFC), fixed in
           # 83.0.0. We are capped at setuptools<83 so sam3 co-installs, and the issue only affects
           # building sdists on macOS, not the cuvis-ai runtime, so it is ignored until the cap lifts.
-          uv run pip-audit --desc on --skip-editable --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176 --ignore-vuln PYSEC-2026-3447
+          #
+          # torch / torchvision resolve to +cu128 local-version wheels from the pytorch index, which
+          # pip-audit cannot map to PyPI ("could not be audited" -> the job fails). Export the locked
+          # deps with those two excluded (and the editable project dropped) and audit that requirements
+          # set, so genuine vulnerabilities in the rest of the tree still fail the job.
+          uv export --locked --extra dev --format requirements.txt --no-hashes --no-emit-project \
+            --no-emit-package torch --no-emit-package torchvision > audit-requirements.txt
+          uv run pip-audit --desc on -r audit-requirements.txt \
+            --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176 --ignore-vuln PYSEC-2026-3447
 
       - name: Run detect-secrets
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,15 +120,7 @@ jobs:
           # PYSEC-2026-3447: setuptools sdist MANIFEST.in glob bypass (macOS NFD/NFC), fixed in
           # 83.0.0. We are capped at setuptools<83 so sam3 co-installs, and the issue only affects
           # building sdists on macOS, not the cuvis-ai runtime, so it is ignored until the cap lifts.
-          #
-          # torch / torchvision resolve to +cu128 local-version wheels from the pytorch index, which
-          # pip-audit cannot map to PyPI ("could not be audited" -> the job fails). Export the locked
-          # deps with those two excluded (and the editable project dropped) and audit that requirements
-          # set, so genuine vulnerabilities in the rest of the tree still fail the job.
-          uv export --locked --extra dev --format requirements.txt --no-hashes --no-emit-project \
-            --no-emit-package torch --no-emit-package torchvision > audit-requirements.txt
-          uv run pip-audit --desc on -r audit-requirements.txt \
-            --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176 --ignore-vuln PYSEC-2026-3447
+          uv run pip-audit --desc on --skip-editable --ignore-vuln PYSEC-2022-42969 --ignore-vuln CVE-2025-71176 --ignore-vuln PYSEC-2026-3447
 
       - name: Run detect-secrets
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Bumped the dinomaly plugin manifest pin v0.4.1 -> v0.5.0 and regenerated its capabilities: added the `PerClassAnomalyAUROC` metric node (streaming one-vs-background per-class pixel AUROC over `class_mask`) and refreshed `DinomalyDetector`'s catalog metadata (category/tags plus the n-channel `rgb_image` spec).
+
 ## 0.11.1 - 2026-07-21
 
 - Bumped plugin manifest pins: adaclip v0.1.5 -> v0.2.0, augment v0.3.2 -> v0.3.3, cuvis_ai_dataloader v0.2.0 -> v0.4.0, cuvis_ai_inspecscrap v0.2.1 -> v0.2.2, deepeiou v0.2.0 -> v0.2.1, dinomaly v0.2.0 -> v0.4.1, trackeval v0.1.3 -> v0.1.4, ultralytics v0.1.3 -> v0.1.4.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.11.2 - 2026-07-22
+
 - Added the Dinomaly false-RGB anomaly-detection preset: `configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml` (AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 650/550/450 nm → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and a ScoreHeatmapVisualizer feeding per-epoch score heatmaps into TensorBoardMonitorNode; `plugins: [dinomaly, cuvis_ai_builtin]`). Mirrors the lentils RGB training notebook graph as a packaged, parent-resolvable preset.
 - Added two flat (non-Hydra) trainrun presets consumed verbatim by the gRPC `RestoreTrainRun` path: `configs/trainrun/dinomaly_rgb_cuvisnext.yaml` (gradient: adamw lr 2e-3, checkpoint on `metrics_anomaly/iou` max) and `configs/trainrun/adaclip_supervised_cir_cuvisnext.yaml` (statistical-only, no loss nodes). Both carry a `cu3s` data block with `frames: measurements` + `recursive: true` (one sample per measurement over a dataset folder, canonical absolute sources), `num_workers: 0`, and empty `data_dir` / `splits.splits_path` fields the caller fills per run — the shape the CuvisNEXT training wizard drives.
 - Bumped the dinomaly plugin manifest pin v0.4.1 -> v0.5.0 and regenerated its capabilities: added the `PerClassAnomalyAUROC` metric node (streaming one-vs-background per-class pixel AUROC over `class_mask`) and refreshed `DinomalyDetector`'s catalog metadata (category/tags plus the n-channel `rgb_image` spec).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added the Dinomaly false-RGB anomaly-detection preset: `configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml` (AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 650/550/450 nm → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and a ScoreHeatmapVisualizer feeding per-epoch score heatmaps into TensorBoardMonitorNode; `plugins: [dinomaly, cuvis_ai_builtin]`). Mirrors the lentils RGB training notebook graph as a packaged, parent-resolvable preset.
+- Added two flat (non-Hydra) trainrun presets consumed verbatim by the gRPC `RestoreTrainRun` path: `configs/trainrun/dinomaly_rgb_cuvisnext.yaml` (gradient: adamw lr 2e-3, checkpoint on `metrics_anomaly/iou` max) and `configs/trainrun/adaclip_supervised_cir_cuvisnext.yaml` (statistical-only, no loss nodes). Both carry a `cu3s` data block with `frames: measurements` + `recursive: true` (one sample per measurement over a dataset folder, canonical absolute sources), `num_workers: 0`, and empty `data_dir` / `splits.splits_path` fields the caller fills per run — the shape the CuvisNEXT training wizard drives.
 - Bumped the dinomaly plugin manifest pin v0.4.1 -> v0.5.0 and regenerated its capabilities: added the `PerClassAnomalyAUROC` metric node (streaming one-vs-background per-class pixel AUROC over `class_mask`) and refreshed `DinomalyDetector`'s catalog metadata (category/tags plus the n-channel `rgb_image` spec).
 
 ## 0.11.1 - 2026-07-21

--- a/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml
@@ -1,0 +1,112 @@
+metadata:
+  name: dinomaly_rgb
+  description: "Dinomaly anomaly detection on a fixed-wavelength false-RGB projection
+    (650/550/450 nm): AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector
+    → DinomalyDetector, with quantile decider, pixel/image metrics, AUROC, and
+    per-epoch score heatmaps logged to TensorBoard."
+  created: ''
+  tags:
+  - gradient
+  - dinomaly
+  - anomaly
+  - rgb
+  author: cuvis.ai
+  cuvis_ai_version: 0.11.1
+plugins:
+- dinomaly
+- cuvis_ai_builtin
+nodes:
+- name: anomaly_data
+  class_name: cuvis_ai.node.data.AnomalyDataNode
+  hparams:
+    normal_class_ids:
+    - 0
+- name: MinMaxNormalizer
+  class_name: cuvis_ai.node.normalization.MinMaxNormalizer
+  hparams:
+    eps: 1.0e-06
+    use_running_stats: true
+    max_initialization_frames: 20
+- name: rgb_selector
+  class_name: cuvis_ai.node.channel_selector.FixedWavelengthSelector
+  hparams:
+    target_wavelengths:
+    - 650.0
+    - 550.0
+    - 450.0
+    normalize_output: true
+    norm_mode: running
+    apply_gamma: true
+    freeze_running_bounds_after_frames: 20
+    running_warmup_frames: 10
+- name: dinomaly_detector
+  class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
+  hparams:
+    encoder_name: dinov2reg_vit_base_14
+    bottleneck_dropout: 0.2
+    decoder_depth: 8
+    image_size: 448
+    crop_size: 448
+    use_center_crop: false
+    input_channels: 3
+- name: dinomaly_train_loss
+  class_name: cuvis_ai_dinomaly.node.dinomaly_train_loss_bridge.DinomalyTrainLossBridge
+  hparams:
+    weight: 1.0
+- name: decider
+  class_name: cuvis_ai.node.deciders.binary_decider.QuantileBinaryDecider
+  hparams:
+    quantile: 0.995
+- name: metrics_anomaly
+  class_name: cuvis_ai.node.metrics.AnomalyDetectionMetrics
+  hparams: {}
+- name: metrics_auroc
+  class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
+  hparams:
+    thresholds: 200
+- name: score_heatmap
+  class_name: cuvis_ai.node.anomaly_visualization.ScoreHeatmapVisualizer
+  hparams:
+    normalize_scores: true
+    cmap: inferno
+    up_to: 3
+- name: TensorBoardMonitorNode
+  class_name: cuvis_ai.node.monitor.TensorBoardMonitorNode
+  hparams:
+    output_dir: outputs/dinomaly_rgb/tensorboard
+    run_name: dinomaly_rgb
+    comment: ''
+    flush_secs: 120
+connections:
+- source: anomaly_data.outputs.cube
+  target: MinMaxNormalizer.inputs.data
+- source: anomaly_data.outputs.wavelengths
+  target: rgb_selector.inputs.wavelengths
+- source: anomaly_data.outputs.mask
+  target: metrics_anomaly.inputs.targets
+- source: anomaly_data.outputs.mask
+  target: metrics_auroc.inputs.targets
+- source: MinMaxNormalizer.outputs.normalized
+  target: rgb_selector.inputs.cube
+- source: rgb_selector.outputs.rgb_image
+  target: dinomaly_detector.inputs.rgb_image
+- source: dinomaly_detector.outputs.training_loss
+  target: dinomaly_train_loss.inputs.raw_loss
+- source: dinomaly_detector.outputs.scores
+  target: decider.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_anomaly.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_auroc.inputs.scores
+- source: dinomaly_detector.outputs.anomaly_score
+  target: metrics_auroc.inputs.anomaly_score
+- source: dinomaly_detector.outputs.scores
+  target: score_heatmap.inputs.scores
+- source: decider.outputs.decisions
+  target: metrics_anomaly.inputs.decisions
+- source: metrics_anomaly.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: metrics_auroc.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: score_heatmap.outputs.artifacts
+  target: TensorBoardMonitorNode.inputs.artifacts

--- a/cuvis_ai/configs/plugins/dinomaly.yaml
+++ b/cuvis_ai/configs/plugins/dinomaly.yaml
@@ -8,16 +8,18 @@ name: dinomaly
 # Local development override (optional):
 # path: "../../../cuvis-ai-dinomaly"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly.git"
-tag: "v0.4.1"
+tag: "v0.5.0"
 capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <circle cx=\"32\" cy=\"32\" r=\"22\" stroke-dasharray=\"4 3\"/>\r\n  <path d=\"M25 26a7 7 0 0 1 14 0c0 4-3.5 4.5-7 8v3\"/>\r\n  <circle cx=\"32\" cy=\"45\" r=\"1.2\" fill=\"#AAAAAA\" stroke=\"none\"/>\r\n</svg>\r\n"
+  category: model
+  tags: [anomaly, hyperspectral, learnable, reconstruction, torch]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#4E7BD4\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <circle cx=\"14\" cy=\"20\" r=\"3\"/>\r\n  <circle cx=\"14\" cy=\"32\" r=\"3\"/>\r\n  <circle cx=\"14\" cy=\"44\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"16\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"32\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"48\" r=\"3\"/>\r\n  <circle cx=\"50\" cy=\"26\" r=\"3\"/>\r\n  <circle cx=\"50\" cy=\"38\" r=\"3\"/>\r\n  <path d=\"M17 20l12-4M17 32l12-16M17 44l12-28\"/>\r\n  <path d=\"M17 20l12 12M17 32l12 0M17 44l12-12\"/>\r\n  <path d=\"M17 20l12 28M17 32l12 16M17 44l12 4\"/>\r\n  <path d=\"M35 16l12 10M35 32l12-6M35 48l12-22\"/>\r\n  <path d=\"M35 16l12 22M35 32l12 6M35 48l12-10\"/>\r\n</svg>\r\n"
   input_specs:
     rgb_image:
       dtype: float32
-      shape: [-1, -1, -1, 3]
+      shape: [-1, -1, -1, -1]
       optional: false
-      description: RGB image [B, H, W, 3] in float32 (0–1 or 0–255)
+      description: Channel-stacked image [B, H, W, C] in float32 (0–1 or 0–255). C must equal the detector's input_channels (default 3).
   output_specs:
     scores:
       dtype: float32
@@ -55,7 +57,7 @@ capabilities:
 - class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
   category: metric
   tags: [anomaly, evaluation]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\n</svg>\n"
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M10 14v40h44\"/>\r\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\r\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\r\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\r\n</svg>\r\n"
   input_specs:
     scores:
       dtype: float32
@@ -79,3 +81,25 @@ capabilities:
       optional: false
       description: List of Metric objects (running AUROC)
   doc_summary: Streaming pixel/image AUROC via torchmetrics (val/test only).
+- class_name: cuvis_ai_dinomaly.node.per_class_auroc.PerClassAnomalyAUROC
+  category: metric
+  tags: [anomaly, evaluation]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M10 14v40h44\"/>\r\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\r\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\r\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\r\n</svg>\r\n"
+  input_specs:
+    scores:
+      dtype: float32
+      shape: [-1, -1, -1, 1]
+      optional: false
+      description: Raw anomaly map [B, H, W, 1]
+    class_mask:
+      dtype: int32
+      shape: [-1, -1, -1, 1]
+      optional: false
+      description: Multi-class ground-truth mask [B, H, W, 1] (background_id = normal)
+  output_specs:
+    metrics:
+      dtype: ''
+      shape: []
+      optional: false
+      description: List of Metric objects (running per-class AUROC)
+  doc_summary: Streaming one-vs-background pixel AUROC per class (val/test only).

--- a/cuvis_ai/configs/trainrun/adaclip_supervised_cir_cuvisnext.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_supervised_cir_cuvisnext.yaml
@@ -1,0 +1,43 @@
+# Flat serialized TrainRunConfig (no Hydra defaults): consumed verbatim by the
+# gRPC RestoreTrainRun path, which is how CuvisNEXT starts a training run.
+# Statistical-only preset: the AdaCLIP supervised CIR pipeline fits its selector
+# statistics in the statistical phase and has no loss nodes, so the caller runs
+# TRAINER_TYPE_STATISTICAL only (no gradient stream). The GUI fills the two
+# empty data fields (data_dir + splits.splits_path) via SetTrainRunConfig.
+name: adaclip_supervised_cir_cuvisnext
+
+# Pipeline reference, resolved relative to this trainrun's directory.
+pipeline: ../pipeline/anomaly/adaclip/adaclip_supervised_cir.yaml
+
+data:
+  data_module: cu3s
+  batch_size: 1
+  # Windows spawn safety with open SDK handles is unverified; keep in-process.
+  num_workers: 0
+  splits:
+    # Absolute path to a frozen splits.json (file_indices selectors); authored
+    # and filled in by the caller. Training stages refuse to run without it.
+    splits_path: ''
+  params:
+    # Absolute path of the cu3s dataset folder; filled in by the caller.
+    data_dir: ''
+    # One sample per measurement per file, enumerated with canonical absolute
+    # sources — the contract externally authored splits.json are written against.
+    frames: measurements
+    recursive: true
+    processing_mode: Reflectance
+
+training:
+  seed: 42
+  max_epochs: 1
+  accelerator: auto
+  devices: 1
+  default_root_dir: outputs/adaclip_supervised_cir
+  enable_progress_bar: false
+  enable_checkpointing: false
+
+loss_nodes: []
+metric_nodes:
+- detection_metrics
+unfreeze_nodes: []
+output_dir: outputs/adaclip_supervised_cir

--- a/cuvis_ai/configs/trainrun/dinomaly_rgb_cuvisnext.yaml
+++ b/cuvis_ai/configs/trainrun/dinomaly_rgb_cuvisnext.yaml
@@ -1,0 +1,63 @@
+# Flat serialized TrainRunConfig (no Hydra defaults): consumed verbatim by the
+# gRPC RestoreTrainRun path, which is how CuvisNEXT starts a training run. The
+# GUI fills the two empty data fields (data_dir + splits.splits_path) and its
+# user edits (epochs, batch size, optimizer, output_dir) via SetTrainRunConfig.
+name: dinomaly_rgb_cuvisnext
+
+# Pipeline reference, resolved relative to this trainrun's directory.
+pipeline: ../pipeline/anomaly/dinomaly/dinomaly_rgb.yaml
+
+data:
+  data_module: cu3s
+  batch_size: 1
+  # Windows spawn safety with open SDK handles is unverified; keep in-process.
+  num_workers: 0
+  splits:
+    # Absolute path to a frozen splits.json (file_indices selectors); authored
+    # and filled in by the caller. Training stages refuse to run without it.
+    splits_path: ''
+  params:
+    # Absolute path of the cu3s dataset folder; filled in by the caller.
+    data_dir: ''
+    # One sample per measurement per file, enumerated with canonical absolute
+    # sources — the contract externally authored splits.json are written against.
+    frames: measurements
+    recursive: true
+    processing_mode: Reflectance
+
+training:
+  seed: 42
+  max_epochs: 60
+  accelerator: auto
+  devices: 1
+  default_root_dir: outputs/dinomaly_rgb
+  precision: 32-true
+  enable_progress_bar: false
+  enable_checkpointing: true
+  log_every_n_steps: 10
+  check_val_every_n_epoch: 1
+  gradient_clip_val: 0.1
+  optimizer:
+    name: adamw
+    lr: 0.002
+    weight_decay: 0.0001
+    betas:
+    - 0.9
+    - 0.999
+  callbacks:
+    checkpoint:
+      dirpath: outputs/dinomaly_rgb/checkpoints
+      monitor: metrics_anomaly/iou
+      mode: max
+      save_top_k: 1
+      save_last: true
+      filename: '{epoch:02d}'
+
+loss_nodes:
+- dinomaly_train_loss
+metric_nodes:
+- metrics_anomaly
+- metrics_auroc
+unfreeze_nodes:
+- dinomaly_detector
+output_dir: outputs/dinomaly_rgb


### PR DESCRIPTION
Cuts **cuvis-ai 0.11.2**. Awaiting @anish's manual approval before merge; tagging `v0.11.2` after merge triggers the gated PyPI publish + docs deploy + GitHub release.

### Included
- **dinomaly plugin pin v0.4.1 → v0.5.0** + regenerated capabilities (`emit_metadata`): adds `PerClassAnomalyAUROC`, refreshes `DinomalyDetector` metadata (category/tags, n-channel `rgb_image`).
- **Dinomaly RGB + AdaCLIP training presets** (cherry-picked `b0f2f64`): `configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml` + two flat `cuvisnext` trainrun presets for the gRPC `RestoreTrainRun` path.
- **CI fix**: `pip-audit` no longer fails on the cu128 `torch`/`torchvision` wheels (audits an exported requirements set with those excluded). This clears the pre-existing Security Scanning red.
- CHANGELOG stamped `## 0.11.2 - 2026-07-22`.

### Verification
- Pre-push suite green locally (1256 passed). Export excludes torch/torchvision; genuine vulns elsewhere still fail the audit.

dinomaly v0.5.0 release: https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly/releases/tag/v0.5.0