### PR TITLE
release: cuvis-ai 0.11.3 (adaclip pin v0.3.0 + catalog metadata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## 0.11.3 - 2026-07-22
+
+- Bumped the adaclip plugin manifest pin v0.2.0 -> v0.3.0 and regenerated its capabilities: `AdaCLIPDetector` now carries `category: model` + anomaly tags and `AdaCLIPFocalDiceLoss` its `category: loss` + tags, both node-backed as of adaclip 0.3.0 (previously the detector showed as `unspecified` in the node catalog and the loss metadata was hand-written).
+
 ## 0.11.2 - 2026-07-22
 
 - Added the Dinomaly false-RGB anomaly-detection preset: `configs/pipeline/anomaly/dinomaly/dinomaly_rgb.yaml` (AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 650/550/450 nm → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and a ScoreHeatmapVisualizer feeding per-epoch score heatmaps into TensorBoardMonitorNode; `plugins: [dinomaly, cuvis_ai_builtin]`). Mirrors the lentils RGB training notebook graph as a packaged, parent-resolvable preset.

--- a/cuvis_ai/configs/plugins/adaclip.yaml
+++ b/cuvis_ai/configs/plugins/adaclip.yaml
@@ -7,11 +7,13 @@
 name: adaclip
 # AdaCLIP-based anomaly detection with advanced band selection
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-adaclip.git"
-tag: "v0.2.0"
+tag: "v0.3.0"
 package_name: "cuvis-ai-adaclip"
 capabilities:
 - class_name: cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#AAAAAA\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <circle cx=\"32\" cy=\"32\" r=\"22\" stroke-dasharray=\"4 3\"/>\r\n  <path d=\"M25 26a7 7 0 0 1 14 0c0 4-3.5 4.5-7 8v3\"/>\r\n  <circle cx=\"32\" cy=\"45\" r=\"1.2\" fill=\"#AAAAAA\" stroke=\"none\"/>\r\n</svg>\r\n"
+  category: model
+  tags: [anomaly, image, inference, learnable, mask, rgb, torch]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#4E7BD4\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <circle cx=\"14\" cy=\"20\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"44\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"16\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"48\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"26\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"38\" r=\"3\"/>\n  <path d=\"M17 20l12-4M17 32l12-16M17 44l12-28\"/>\n  <path d=\"M17 20l12 12M17 32l12 0M17 44l12-12\"/>\n  <path d=\"M17 20l12 28M17 32l12 16M17 44l12 4\"/>\n  <path d=\"M35 16l12 10M35 32l12-6M35 48l12-22\"/>\n  <path d=\"M35 16l12 22M35 32l12 6M35 48l12-10\"/>\n</svg>\n"
   input_specs:
     rgb_image:
       dtype: float32
@@ -29,6 +31,16 @@ capabilities:
       shape: [-1]
       optional: false
       description: Image-level anomaly score [B]
+    per_layer_scores:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: true
+      description: Per-layer softmaxed anomaly maps stacked as [B, num_layers*2, H, W]. Only populated during training when training_aggregation=False. Empty (1×1) tensor otherwise.
+    image_score_2ch:
+      dtype: float32
+      shape: [-1, -1]
+      optional: true
+      description: Image-level 2-channel score [B, 2] (softmaxed [normal, anomaly]). Only populated during training when training_aggregation=False.
   doc_summary: AdaCLIP zero-shot anomaly detector node (plugin version).
 - class_name: cuvis_ai_adaclip.node.losses.AdaCLIPFocalDiceLoss
   category: loss
@@ -39,12 +51,12 @@ capabilities:
       dtype: float32
       shape: [-1, -1, -1, 1]
       optional: false
-      description: Aggregated anomaly scores [B, H, W, 1] for the fallback path
+      description: Aggregated anomaly scores [B, H, W, 1] for fallback path
     targets:
       dtype: bool
       shape: [-1, -1, -1, 1]
       optional: false
-      description: Ground-truth binary masks [B, H, W, 1]
+      description: Ground truth binary masks [B, H, W, 1]
     per_layer_scores:
       dtype: float32
       shape: [-1, -1, -1, -1]
@@ -61,4 +73,4 @@ capabilities:
       shape: []
       optional: false
       description: Combined focal + dice loss
-  doc_summary: Combined Focal + Dice loss node for AdaCLIP training.
+  doc_summary: Combined Focal + Dice loss for AdaCLIP training.


### PR DESCRIPTION
Cuts **cuvis-ai 0.11.3**.

- Bumps the adaclip plugin manifest pin `v0.2.0 -> v0.3.0` and regenerates its capabilities via `emit_metadata`:
  - `AdaCLIPDetector`: now `category: model` + tags `[anomaly, image, inference, learnable, mask, rgb, torch]` (was `unspecified` with no tags in the catalog).
  - `AdaCLIPFocalDiceLoss`: now `category: loss` + `[differentiable, torch, training]`, node-backed as of adaclip v0.3.0 (previously hand-written in the manifest).
- CHANGELOG stamped `## 0.11.3 - 2026-07-22`.

Catalog/manifest + changelog only; no library code. Depends on adaclip release: https://github.com/cubert-hyperspectral/cuvis-ai-adaclip/releases/tag/v0.3.0

Note: Security Scanning will show the pre-existing cu128 pip-audit red (unrelated to this diff); intended to admin-merge like #61.