### PR TITLE
Pin sam3 to v0.3.0 (shared ViT backbone)

### DIFF
--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.2.1"  # schemas 0.8.0 / core 0.11.0 floors + click/pillow security bumps
+tag: "v0.3.0"  # process-wide shared ViT backbone for fast SAM3 pipeline switching
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation


### PR DESCRIPTION
Bumps the sam3 plugin manifest from `v0.2.1` to the `v0.3.0` release.

v0.3.0 adds the process-wide shared SAM3 vision-language backbone: all SAM3 nodes in one runtime share a single GPU-resident ViT + text backbone, so switching between two SAM3 pipelines reuses the resident backbone and rebuilds only the lightweight heads instead of re-reading the 3.4GB `sam3.pt` and reconstructing the full model. This is what makes the CuvisNEXT annotate/propagate switch fast.

- One-line manifest change: `path:` dev source removed, `repo:` + `tag: v0.3.0` restored.
- Backward compatible: the shared backbone is transparent to existing pipelines; ports and node classes unchanged since v0.2.0.
- Release: https://github.com/cubert-hyperspectral/cuvis-ai-sam3/releases/tag/v0.3.0

Pairs with cuvis-next MR !193 (same target branch).