### PR TITLE
release: cuvis-ai 0.11.5 (sam3 pin v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.5 - 2026-07-29
+
+- Bumped the sam3 plugin manifest pin v0.3.0 -> v0.3.1: streaming propagation survives a failed stream (explicit needs-seed recovery surfacing the original error once, instead of poisoning the session with "generator exhausted early"), prompt-frame image features are pinned against all three eviction paths until consolidated (fixes "Image features for frame N are not cached" mid-stream), and `SAM3PointExpansion`'s embedding cache keys on frame content in addition to `frame_id` so repeated ids across videos can no longer serve stale embeddings.
+
 ## 0.11.4 - 2026-07-28
 
 - Added the Dinomaly CIR anomaly-detection preset: `configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml` (AnomalyDataNode → MinMaxNormalizer → FixedWavelengthSelector 860/670/560 nm NIR/R/G false-color → DinomalyDetector, with QuantileBinaryDecider, AnomalyDetectionMetrics, the plugin's AUROC metrics, and per-epoch score heatmaps into TensorBoardMonitorNode). Sibling of the 0.11.2 `dinomaly_rgb` preset for SWIR-leaning scenes where CIR separates anomalies better than visible RGB.

--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.3.0"  # process-wide shared ViT backbone for fast SAM3 pipeline switching
+tag: "v0.3.1"  # streaming-propagation hardening: needs-seed recovery, pinned prompt-frame features
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation


### PR DESCRIPTION
## What

Release **0.11.5**: bump the sam3 plugin manifest pin v0.3.0 -> v0.3.1.

cuvis-ai-sam3 v0.3.1 (https://github.com/cubert-hyperspectral/cuvis-ai-sam3/releases/tag/v0.3.1) hardens the interactive SAM3 flow that CuvisNEXT drives:

- **Needs-seed recovery**: any exception inside the propagation generator tears the stream state down and surfaces the ORIGINAL error exactly once, instead of poisoning the session with "generator exhausted early" on every later frame. A seed-less start ("No points are provided") gets the same clean state; the next non-empty prompt seeds a fresh stream.
- **Pinned prompt-frame features**: prompt-frame image features are pinned against all three eviction paths (node pruning, detector per-step pop, tracker miss-path rebind) until the tracker consolidates that frame - fixes "Image features for frame N are not cached" raised mid-stream by the periodic reconditioning pass while the video tracker runs with `backbone=None`.
- **Content-keyed expansion cache**: `SAM3PointExpansion` keys its per-frame embedding cache on frame content in addition to `frame_id`, so repeated ids across videos/counter restarts can no longer serve stale embeddings (wrong-object masks).

## Why

Node-side half of the CuvisNEXT annotate -> propagate -> annotate fix; the app-side intent model lands separately in cuvis-next. Without this pin bump, child envs keep composing v0.3.0 and the mid-stream prompt paths stay unhardened.

## Verification

- 156 pytest green in cuvis-ai-sam3 at the tag (new regression cases fail on v0.3.0 behavior).
- End-to-end GUI verification against a CuvisNEXT build: the incident flow plus re-propagate-twice and collapsed-expander refine all pass with no error dialogs.
- Pre-push gate here: 1257 passed.
