### PR TITLE
fix(configs): source cuvis_ai_builtin from git, not a deployment-dependent path

### DIFF
--- a/cuvis_ai/configs/data/lentils.yaml
+++ b/cuvis_ai/configs/data/lentils.yaml
@@ -4,8 +4,11 @@
 
 data_module: cu3s
 splits:
-  # Selectors over the cu3s measurement universe; val/test disjoint so the default
-  # leakage_check (error) passes.
+  constraints:
+  - kind: no_split_overlap
+    severity: error
+  # Selectors over the cu3s measurement universe; val/test disjoint so the declared
+  # no_split_overlap (error) constraint passes.
   train:
     - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2, 3]}
   val:

--- a/cuvis_ai/configs/data/tracking_cap_and_car.yaml
+++ b/cuvis_ai/configs/data/tracking_cap_and_car.yaml
@@ -1,5 +1,8 @@
 data_module: cu3s
 splits:
+  constraints:
+  - kind: no_split_overlap
+    severity: error
   # Frame IDs - fill after running inspect mode
   train:
     - {kind: file_indices, source: &src "D:\\data\\2024_05_22_cap_and_car_2XM_setup\\2024_05_22__cap_and_car_50mm\\Auto_002.cu3s", ids: [696, 708, 720, 855, 858, 871, 881, 887]}

--- a/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
@@ -1,20 +1,17 @@
 metadata:
-  name: dinomaly_cir_lentils
-  description: "Inference-only variant of dinomaly_cir, wired to match the published
-    lentils checkpoint (XMR_Demo_Industrial_Foreign_Object_Detection_Lentils,
-    dinomaly_cir_full_pipeline/dinomaly_cir.pt). Same AnomalyDataNode -> MinMaxNormalizer
-    -> 860/670/560 selector -> DinomalyDetector spine as the training preset, but with
-    that checkpoint's two-stage decider calibration and without the training-only
-    metrics, heatmap and TensorBoard nodes. Load it with the .pt: the normalizer's
-    running stats live there, not in this file."
+  name: dinomaly_cir
+  description: "Dinomaly anomaly detection on a fixed-wavelength CIR (color-infrared)
+    false-color projection (860/670/560 nm = NIR/R/G): AnomalyDataNode → MinMaxNormalizer
+    → FixedWavelengthSelector → DinomalyDetector, with quantile decider, pixel/image
+    metrics, AUROC, and per-epoch score heatmaps logged to TensorBoard."
   created: ''
   tags:
+  - gradient
   - dinomaly
   - anomaly
   - cir
-  - inference
   author: cuvis.ai
-  cuvis_ai_version: 0.11.5
+  cuvis_ai_version: 0.11.1
 plugins:
 - dinomaly
 - cuvis_ai_builtin
@@ -28,10 +25,8 @@ nodes:
   class_name: cuvis_ai.node.normalization.MinMaxNormalizer
   hparams:
     eps: 1.0e-06
-    # Bounds come from the checkpoint (0 .. 18783, raw counts). Switching this to false
-    # would normalize per frame, which is not the distribution the detector was trained
-    # on and would invalidate the decider's image_threshold below.
     use_running_stats: true
+    max_initialization_frames: 20
 - name: cir_selector
   class_name: cuvis_ai.node.channel_selector.FixedWavelengthSelector
   hparams:
@@ -43,9 +38,7 @@ nodes:
     norm_mode: running
     apply_gamma: true
     freeze_running_bounds_after_frames: 20
-    # 0, not the preset's 10: the checkpoint carries per-channel bounds, so there is
-    # nothing to warm up and a warmup would ignore them for the first frames.
-    running_warmup_frames: 0
+    running_warmup_frames: 10
 - name: dinomaly_detector
   class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
   hparams:
@@ -56,24 +49,64 @@ nodes:
     crop_size: 448
     use_center_crop: false
     input_channels: 3
-- name: decider
-  class_name: cuvis_ai.node.deciders.two_stage_decider.TwoStageBinaryDecider
+- name: dinomaly_train_loss
+  class_name: cuvis_ai_dinomaly.node.dinomaly_train_loss_bridge.DinomalyTrainLossBridge
   hparams:
-    # Gate the frame on the mean of the top-0.1% per-pixel scores before thresholding
-    # pixels. Without this gate a bare quantile marks the top 0.5% of pixels on every
-    # frame, so clean product reads as permanently contaminated.
-    image_threshold: 0.14
-    top_k_fraction: 0.001
+    weight: 1.0
+- name: decider
+  class_name: cuvis_ai.node.deciders.binary_decider.QuantileBinaryDecider
+  hparams:
     quantile: 0.995
-    reduce_dims: null
+- name: metrics_anomaly
+  class_name: cuvis_ai.node.metrics.AnomalyDetectionMetrics
+  hparams: {}
+- name: metrics_auroc
+  class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
+  hparams:
+    thresholds: 200
+- name: score_heatmap
+  class_name: cuvis_ai.node.anomaly_visualization.ScoreHeatmapVisualizer
+  hparams:
+    normalize_scores: true
+    cmap: inferno
+    up_to: 3
+- name: TensorBoardMonitorNode
+  class_name: cuvis_ai.node.monitor.TensorBoardMonitorNode
+  hparams:
+    output_dir: outputs/dinomaly_cir/tensorboard
+    run_name: dinomaly_cir
+    comment: ''
+    flush_secs: 120
 connections:
 - source: anomaly_data.outputs.cube
   target: MinMaxNormalizer.inputs.data
 - source: anomaly_data.outputs.wavelengths
   target: cir_selector.inputs.wavelengths
+- source: anomaly_data.outputs.mask
+  target: metrics_anomaly.inputs.targets
+- source: anomaly_data.outputs.mask
+  target: metrics_auroc.inputs.targets
 - source: MinMaxNormalizer.outputs.normalized
   target: cir_selector.inputs.cube
 - source: cir_selector.outputs.rgb_image
   target: dinomaly_detector.inputs.rgb_image
+- source: dinomaly_detector.outputs.training_loss
+  target: dinomaly_train_loss.inputs.raw_loss
 - source: dinomaly_detector.outputs.scores
   target: decider.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_anomaly.inputs.logits
+- source: dinomaly_detector.outputs.scores
+  target: metrics_auroc.inputs.scores
+- source: dinomaly_detector.outputs.anomaly_score
+  target: metrics_auroc.inputs.anomaly_score
+- source: dinomaly_detector.outputs.scores
+  target: score_heatmap.inputs.scores
+- source: decider.outputs.decisions
+  target: metrics_anomaly.inputs.decisions
+- source: metrics_anomaly.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: metrics_auroc.outputs.metrics
+  target: TensorBoardMonitorNode.inputs.metrics
+- source: score_heatmap.outputs.artifacts
+  target: TensorBoardMonitorNode.inputs.artifacts

--- a/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml
@@ -1,17 +1,20 @@
 metadata:
-  name: dinomaly_cir
-  description: "Dinomaly anomaly detection on a fixed-wavelength CIR (color-infrared)
-    false-color projection (860/670/560 nm = NIR/R/G): AnomalyDataNode → MinMaxNormalizer
-    → FixedWavelengthSelector → DinomalyDetector, with quantile decider, pixel/image
-    metrics, AUROC, and per-epoch score heatmaps logged to TensorBoard."
+  name: dinomaly_cir_lentils
+  description: "Inference-only variant of dinomaly_cir, wired to match the published
+    lentils checkpoint (XMR_Demo_Industrial_Foreign_Object_Detection_Lentils,
+    dinomaly_cir_full_pipeline/dinomaly_cir.pt). Same AnomalyDataNode -> MinMaxNormalizer
+    -> 860/670/560 selector -> DinomalyDetector spine as the training preset, but with
+    that checkpoint's two-stage decider calibration and without the training-only
+    metrics, heatmap and TensorBoard nodes. Load it with the .pt: the normalizer's
+    running stats live there, not in this file."
   created: ''
   tags:
-  - gradient
   - dinomaly
   - anomaly
   - cir
+  - inference
   author: cuvis.ai
-  cuvis_ai_version: 0.11.1
+  cuvis_ai_version: 0.11.5
 plugins:
 - dinomaly
 - cuvis_ai_builtin
@@ -25,8 +28,10 @@ nodes:
   class_name: cuvis_ai.node.normalization.MinMaxNormalizer
   hparams:
     eps: 1.0e-06
+    # Bounds come from the checkpoint (0 .. 18783, raw counts). Switching this to false
+    # would normalize per frame, which is not the distribution the detector was trained
+    # on and would invalidate the decider's image_threshold below.
     use_running_stats: true
-    max_initialization_frames: 20
 - name: cir_selector
   class_name: cuvis_ai.node.channel_selector.FixedWavelengthSelector
   hparams:
@@ -38,7 +43,9 @@ nodes:
     norm_mode: running
     apply_gamma: true
     freeze_running_bounds_after_frames: 20
-    running_warmup_frames: 10
+    # 0, not the preset's 10: the checkpoint carries per-channel bounds, so there is
+    # nothing to warm up and a warmup would ignore them for the first frames.
+    running_warmup_frames: 0
 - name: dinomaly_detector
   class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
   hparams:
@@ -49,64 +56,24 @@ nodes:
     crop_size: 448
     use_center_crop: false
     input_channels: 3
-- name: dinomaly_train_loss
-  class_name: cuvis_ai_dinomaly.node.dinomaly_train_loss_bridge.DinomalyTrainLossBridge
-  hparams:
-    weight: 1.0
 - name: decider
-  class_name: cuvis_ai.node.deciders.binary_decider.QuantileBinaryDecider
+  class_name: cuvis_ai.node.deciders.two_stage_decider.TwoStageBinaryDecider
   hparams:
+    # Gate the frame on the mean of the top-0.1% per-pixel scores before thresholding
+    # pixels. Without this gate a bare quantile marks the top 0.5% of pixels on every
+    # frame, so clean product reads as permanently contaminated.
+    image_threshold: 0.14
+    top_k_fraction: 0.001
     quantile: 0.995
-- name: metrics_anomaly
-  class_name: cuvis_ai.node.metrics.AnomalyDetectionMetrics
-  hparams: {}
-- name: metrics_auroc
-  class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
-  hparams:
-    thresholds: 200
-- name: score_heatmap
-  class_name: cuvis_ai.node.anomaly_visualization.ScoreHeatmapVisualizer
-  hparams:
-    normalize_scores: true
-    cmap: inferno
-    up_to: 3
-- name: TensorBoardMonitorNode
-  class_name: cuvis_ai.node.monitor.TensorBoardMonitorNode
-  hparams:
-    output_dir: outputs/dinomaly_cir/tensorboard
-    run_name: dinomaly_cir
-    comment: ''
-    flush_secs: 120
+    reduce_dims: null
 connections:
 - source: anomaly_data.outputs.cube
   target: MinMaxNormalizer.inputs.data
 - source: anomaly_data.outputs.wavelengths
   target: cir_selector.inputs.wavelengths
-- source: anomaly_data.outputs.mask
-  target: metrics_anomaly.inputs.targets
-- source: anomaly_data.outputs.mask
-  target: metrics_auroc.inputs.targets
 - source: MinMaxNormalizer.outputs.normalized
   target: cir_selector.inputs.cube
 - source: cir_selector.outputs.rgb_image
   target: dinomaly_detector.inputs.rgb_image
-- source: dinomaly_detector.outputs.training_loss
-  target: dinomaly_train_loss.inputs.raw_loss
 - source: dinomaly_detector.outputs.scores
   target: decider.inputs.logits
-- source: dinomaly_detector.outputs.scores
-  target: metrics_anomaly.inputs.logits
-- source: dinomaly_detector.outputs.scores
-  target: metrics_auroc.inputs.scores
-- source: dinomaly_detector.outputs.anomaly_score
-  target: metrics_auroc.inputs.anomaly_score
-- source: dinomaly_detector.outputs.scores
-  target: score_heatmap.inputs.scores
-- source: decider.outputs.decisions
-  target: metrics_anomaly.inputs.decisions
-- source: metrics_anomaly.outputs.metrics
-  target: TensorBoardMonitorNode.inputs.metrics
-- source: metrics_auroc.outputs.metrics
-  target: TensorBoardMonitorNode.inputs.metrics
-- source: score_heatmap.outputs.artifacts
-  target: TensorBoardMonitorNode.inputs.artifacts

--- a/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir_lentils.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir_lentils.yaml
@@ -1,0 +1,79 @@
+metadata:
+  name: dinomaly_cir_lentils
+  description: "Inference-only variant of dinomaly_cir, wired to match the published
+    lentils checkpoint (XMR_Demo_Industrial_Foreign_Object_Detection_Lentils,
+    dinomaly_cir_full_pipeline/dinomaly_cir.pt). Same AnomalyDataNode -> MinMaxNormalizer
+    -> 860/670/560 selector -> DinomalyDetector spine as the training preset, but with
+    that checkpoint's two-stage decider calibration and without the training-only
+    metrics, heatmap and TensorBoard nodes. Load it with the .pt: the normalizer's
+    running stats live there, not in this file."
+  created: ''
+  tags:
+  - dinomaly
+  - anomaly
+  - cir
+  - inference
+  author: cuvis.ai
+  cuvis_ai_version: 0.11.5
+plugins:
+- dinomaly
+- cuvis_ai_builtin
+nodes:
+- name: anomaly_data
+  class_name: cuvis_ai.node.data.AnomalyDataNode
+  hparams:
+    normal_class_ids:
+    - 0
+- name: MinMaxNormalizer
+  class_name: cuvis_ai.node.normalization.MinMaxNormalizer
+  hparams:
+    eps: 1.0e-06
+    # Bounds come from the checkpoint (0 .. 18783, raw counts). Switching this to false
+    # would normalize per frame, which is not the distribution the detector was trained
+    # on and would invalidate the decider's image_threshold below.
+    use_running_stats: true
+- name: cir_selector
+  class_name: cuvis_ai.node.channel_selector.FixedWavelengthSelector
+  hparams:
+    target_wavelengths:
+    - 860.0
+    - 670.0
+    - 560.0
+    normalize_output: true
+    norm_mode: running
+    apply_gamma: true
+    freeze_running_bounds_after_frames: 20
+    # 0, not the preset's 10: the checkpoint carries per-channel bounds, so there is
+    # nothing to warm up and a warmup would ignore them for the first frames.
+    running_warmup_frames: 0
+- name: dinomaly_detector
+  class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
+  hparams:
+    encoder_name: dinov2reg_vit_base_14
+    bottleneck_dropout: 0.2
+    decoder_depth: 8
+    image_size: 448
+    crop_size: 448
+    use_center_crop: false
+    input_channels: 3
+- name: decider
+  class_name: cuvis_ai.node.deciders.two_stage_decider.TwoStageBinaryDecider
+  hparams:
+    # Gate the frame on the mean of the top-0.1% per-pixel scores before thresholding
+    # pixels. Without this gate a bare quantile marks the top 0.5% of pixels on every
+    # frame, so clean product reads as permanently contaminated.
+    image_threshold: 0.14
+    top_k_fraction: 0.001
+    quantile: 0.995
+    reduce_dims: null
+connections:
+- source: anomaly_data.outputs.cube
+  target: MinMaxNormalizer.inputs.data
+- source: anomaly_data.outputs.wavelengths
+  target: cir_selector.inputs.wavelengths
+- source: MinMaxNormalizer.outputs.normalized
+  target: cir_selector.inputs.cube
+- source: cir_selector.outputs.rgb_image
+  target: dinomaly_detector.inputs.rgb_image
+- source: dinomaly_detector.outputs.scores
+  target: decider.inputs.logits

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -1,7 +1,15 @@
 # Built-in cuvis-ai nodes from this repository.
 # Useful when the gRPC server runs in a different venv and cannot import `cuvis_ai.*` directly.
+#
+# Sourced from git, not from a relative path: `path: "../../.."` resolved against the manifest's
+# own directory, which is the checkout root in a source tree but <site-packages> in a wheel
+# install, where there is no project to build. The composer failed outright there.
+# `package_name` is required because a git plugin otherwise defaults it to the manifest key,
+# and the installable is `cuvis-ai`.
 name: cuvis_ai_builtin
-path: "../../.."
+package_name: cuvis-ai
+repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
+tag: "v0.11.5"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform

--- a/cuvis_ai/configs/trainrun/adaclip_baseline.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_baseline.yaml
@@ -11,9 +11,12 @@ defaults:
 
 data:
   # Override splits for this example. train/val/test are disjoint so the
-  # default leakage_check (error) passes; the base lentils val ([1]) would
+  # no_split_overlap (error) constraint passes; the base lentils val ([1]) would
   # otherwise collide with this run's test, so val is overridden explicitly.
   splits:
+    constraints:
+    - kind: no_split_overlap
+      severity: error
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_cir_false_color.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_cir_false_color.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_cir_false_color_optimal_threshold.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_cir_false_color_optimal_threshold.yaml
@@ -4,7 +4,9 @@ pipeline: ../pipeline/anomaly/adaclip/adaclip_cir_false_color_optimal_threshold.
 data:
   data_module: cu3s
   splits:
-    leakage_check: warn  # val/test intentionally identical (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # val/test intentionally identical (small-dataset reuse)
     train:
     - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2, 3]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_cir_false_rg_color.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_cir_false_rg_color.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_high_contrast.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_high_contrast.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_supervised_cir.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_supervised_cir.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_supervised_full_spectrum.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_supervised_full_spectrum.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/adaclip_supervised_windowed_false_rgb.yaml
+++ b/cuvis_ai/configs/trainrun/adaclip_supervised_windowed_false_rgb.yaml
@@ -12,7 +12,9 @@ defaults:
 data:
   # Override splits for this example
   splits:
-    leakage_check: warn  # train/val intentionally share frame 2 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # train/val intentionally share frame 2 (small-dataset reuse)
     train:
       - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2]}
     val:

--- a/cuvis_ai/configs/trainrun/deep_svdd.yaml
+++ b/cuvis_ai/configs/trainrun/deep_svdd.yaml
@@ -12,6 +12,9 @@ defaults:
 
 data:
   splits:
+    constraints:
+    - kind: no_split_overlap
+      severity: error
     train:
     - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0]}
     val:

--- a/cuvis_ai/configs/trainrun/drcnn_adaclip_trainrun.yaml
+++ b/cuvis_ai/configs/trainrun/drcnn_adaclip_trainrun.yaml
@@ -4,7 +4,9 @@ pipeline: ../pipeline/anomaly/adaclip/drcnn_adaclip_gradient.yaml
 data:
   data_module: cu3s
   splits:
-    leakage_check: warn  # val/test intentionally share frame 1 (small-dataset reuse)
+    constraints:
+    - kind: no_split_overlap
+      severity: warn  # val/test intentionally share frame 1 (small-dataset reuse)
     train:
     - {kind: file_indices, source: data/Lentils/Lentils_000.cu3s, ids: [0, 2, 3]}
     val:

--- a/cuvis_ai/configs/trainrun/rx_statistical.yaml
+++ b/cuvis_ai/configs/trainrun/rx_statistical.yaml
@@ -1,4 +1,4 @@
-# @package _global_
+# @package _global_
 
 
 defaults:
@@ -9,7 +9,7 @@ defaults:
 
 name: rx_statistical
 
-# Pipeline reference, resolved relative to this trainrun's directory.
+# Pipeline reference, resolved relative to this trainrun's directory.
 pipeline: ../pipeline/anomaly/rx/rx_statistical.yaml
 
 training:
@@ -39,5 +39,4 @@ unfreeze_nodes: []
 freeze_nodes: []
 metric_nodes:
 - metrics_anomaly
-- sample_metrics
 loss_nodes: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
     # plugin behind its [cu3s] extra, provisioned at runtime when a cu3s run needs it.
     # Builtin/RGB pipelines pull neither cuvis nor cuvis-il, closing the Windows wheel gap.
     # Tests mock the data layer (no plugin dep); the real cu3s reader is tested in the plugin.
-    "cuvis-ai-core>=0.11.2",
-    "cuvis-ai-schemas[full]>=0.8.0",
+    "cuvis-ai-core>=0.12.1",
+    "cuvis-ai-schemas[full]>=0.9.0",
     "pydantic>=2.13.3,<3.0.0",
     "defusedxml>=0.7.1",
     "markupsafe>=3.0.3",
@@ -153,11 +153,6 @@ cuvis_ai = ["assets/node_icons/*.svg", "configs/**/*.yaml"]
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
-# LOCAL ONLY - re-comment before release, like the editable overrides below.
-# Points at the child-runtime CUDA-torch fix (cuvis-ai-core PR #59) so composed child
-# envs get the host's CUDA torch instead of PyPI's CPU-only Windows wheels. Drop this
-# line once that lands in a release and the floor above covers it.
-cuvis-ai-core = { git = "https://github.com/cubert-hyperspectral/cuvis-ai-core.git", branch = "fix/child-runtime-cuda-torch" }
 # Local editable overrides for day-to-day development against working copies of the
 # core libs. Strip (re-comment) before release so CI and PyPI consumers resolve the
 # published floors; these are for local work against sibling checkouts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,11 @@ cuvis_ai = ["assets/node_icons/*.svg", "configs/**/*.yaml"]
 [tool.uv.sources]
 torch = { index = "pytorch-cu128" }
 torchvision = { index = "pytorch-cu128" }
+# LOCAL ONLY - re-comment before release, like the editable overrides below.
+# Points at the child-runtime CUDA-torch fix (cuvis-ai-core PR #59) so composed child
+# envs get the host's CUDA torch instead of PyPI's CPU-only Windows wheels. Drop this
+# line once that lands in a release and the floor above covers it.
+cuvis-ai-core = { git = "https://github.com/cubert-hyperspectral/cuvis-ai-core.git", branch = "fix/child-runtime-cuda-torch" }
 # Local editable overrides for day-to-day development against working copies of the
 # core libs. Strip (re-comment) before release so CI and PyPI consumers resolve the
 # published floors; these are for local work against sibling checkouts.

--- a/tests/configs/test_pipeline_presets_valid.py
+++ b/tests/configs/test_pipeline_presets_valid.py
@@ -1,0 +1,28 @@
+"""Standalone pipeline presets validate even when no trainrun references them.
+
+``test_trainrun_pipeline_references_resolve`` only loads pipelines a trainrun
+points at; a preset shipped for inference only (no trainrun) would never be
+parsed by the suite and could rot silently.
+"""
+
+from pathlib import Path
+
+from cuvis_ai_schemas.pipeline.config import PipelineConfig
+
+_PIPELINES = Path(__file__).resolve().parents[2] / "cuvis_ai" / "configs" / "pipeline"
+
+
+def test_dinomaly_cir_lentils_preset_loads() -> None:
+    """The lentils inference preset parses and keeps the checkpoint-matched spine."""
+    pipeline = PipelineConfig.load_from_file(
+        _PIPELINES / "anomaly" / "dinomaly" / "dinomaly_cir_lentils.yaml"
+    )
+    assert pipeline.metadata.name == "dinomaly_cir_lentils"
+    node_names = {node.name for node in pipeline.nodes}
+    assert node_names == {
+        "anomaly_data",
+        "MinMaxNormalizer",
+        "cir_selector",
+        "dinomaly_detector",
+        "decider",
+    }

--- a/tests/plugins/test_builtin_manifest_location_independent.py
+++ b/tests/plugins/test_builtin_manifest_location_independent.py
@@ -1,0 +1,33 @@
+"""The builtin manifest must parse to the same source wherever the catalog is installed.
+
+``path: "../../.."`` resolved against the manifest's own directory, which is the checkout
+root in a source tree but ``<site-packages>`` in a wheel install, where there is no project
+to build: the composer rejected it with "has no pyproject.toml". Any location-dependent
+source reintroduces that split, so the invariant is tested rather than the specific source
+kind.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from cuvis_ai_schemas.plugin import load_plugin_manifest
+
+pytestmark = pytest.mark.unit
+
+MANIFEST = Path("cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml")
+
+
+def test_builtin_manifest_source_does_not_depend_on_install_location(tmp_path: Path) -> None:
+    relocated = tmp_path / "elsewhere" / MANIFEST.name
+    relocated.parent.mkdir(parents=True)
+    shutil.copyfile(MANIFEST, relocated)
+
+    assert load_plugin_manifest(MANIFEST).model_dump() == load_plugin_manifest(
+        relocated
+    ).model_dump(), (
+        f"{MANIFEST.name} resolves differently depending on where it is installed, so a "
+        "wheel install and a source checkout compose different child environments"
+    )

--- a/tests/plugins/test_builtin_manifest_location_independent.py
+++ b/tests/plugins/test_builtin_manifest_location_independent.py
@@ -25,9 +25,9 @@ def test_builtin_manifest_source_does_not_depend_on_install_location(tmp_path: P
     relocated.parent.mkdir(parents=True)
     shutil.copyfile(MANIFEST, relocated)
 
-    assert load_plugin_manifest(MANIFEST).model_dump() == load_plugin_manifest(
-        relocated
-    ).model_dump(), (
+    assert (
+        load_plugin_manifest(MANIFEST).model_dump() == load_plugin_manifest(relocated).model_dump()
+    ), (
         f"{MANIFEST.name} resolves differently depending on where it is installed, so a "
         "wheel install and a source checkout compose different child environments"
     )

--- a/tests/plugins/test_builtin_manifest_location_independent.py
+++ b/tests/plugins/test_builtin_manifest_location_independent.py
@@ -17,7 +17,13 @@ from cuvis_ai_schemas.plugin import load_plugin_manifest
 
 pytestmark = pytest.mark.unit
 
-MANIFEST = Path("cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml")
+MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "cuvis_ai"
+    / "configs"
+    / "plugins"
+    / "cuvis_ai_builtin.yaml"
+)
 
 
 def test_builtin_manifest_source_does_not_depend_on_install_location(tmp_path: Path) -> None:

--- a/tests/test_split_migration_equivalence.py
+++ b/tests/test_split_migration_equivalence.py
@@ -11,7 +11,13 @@ from pathlib import Path
 
 import pytest
 import yaml
-from cuvis_ai_schemas.training.data import DataSplitConfig, SampleRef
+from cuvis_ai_schemas.training.data import (
+    Constraint,
+    ConstraintKind,
+    ConstraintSeverity,
+    DataSplitConfig,
+    SampleRef,
+)
 
 from cuvis_ai_core.data.selectors import resolve_selectors
 
@@ -45,15 +51,72 @@ def test_config_selectors_resolve_to_expected_ids(config_path, source, expected)
 
 
 def test_overlapping_config_declares_warn():
-    """A migrated config with intentional train/val/test overlap opts out of the hard guard."""
+    """A migrated config with intentional train/val/test overlap downgrades the hard guard."""
     raw = yaml.safe_load(
         (_CONFIGS / "trainrun" / "adaclip_cir_false_color.yaml").read_text(encoding="utf-8")
     )
     splits = DataSplitConfig.model_validate(raw["data"]["splits"])
-    assert splits.leakage_check == "warn"  # train/val share frame 2
+    # train/val share frame 2, so no_split_overlap is declared at warn, not error.
+    assert splits.constraints == [
+        Constraint(kind=ConstraintKind.NO_SPLIT_OVERLAP, severity=ConstraintSeverity.WARN)
+    ]
     universe = _universe("data/Lentils/Lentils_000.cu3s")
     assert _resolved_ids(splits.train, universe) == [0, 2]
     assert _resolved_ids(splits.val, universe) == [2, 4]
+
+
+# Every shipped config with an inline splits block and its declared overlap severity:
+# warn = intentional small-dataset reuse, error = the old schemas-0.8 default hard guard.
+_CONSTRAINT_CASES = [
+    ("trainrun/adaclip_baseline.yaml", ("data", "splits"), ConstraintSeverity.ERROR),
+    ("trainrun/adaclip_cir_false_color.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    (
+        "trainrun/adaclip_cir_false_color_optimal_threshold.yaml",
+        ("data", "splits"),
+        ConstraintSeverity.WARN,
+    ),
+    ("trainrun/adaclip_cir_false_rg_color.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    ("trainrun/adaclip_high_contrast.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    ("trainrun/adaclip_supervised_cir.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    ("trainrun/adaclip_supervised_full_spectrum.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    (
+        "trainrun/adaclip_supervised_windowed_false_rgb.yaml",
+        ("data", "splits"),
+        ConstraintSeverity.WARN,
+    ),
+    ("trainrun/deep_svdd.yaml", ("data", "splits"), ConstraintSeverity.ERROR),
+    ("trainrun/drcnn_adaclip_trainrun.yaml", ("data", "splits"), ConstraintSeverity.WARN),
+    ("data/lentils.yaml", ("splits",), ConstraintSeverity.ERROR),
+    ("data/tracking_cap_and_car.yaml", ("splits",), ConstraintSeverity.ERROR),
+]
+
+
+@pytest.mark.parametrize("rel_path, keys, severity", _CONSTRAINT_CASES, ids=lambda c: str(c))
+def test_inline_splits_declare_overlap_constraint(rel_path, keys, severity):
+    """Every inline splits block declares no_split_overlap explicitly.
+
+    schemas 0.9.0 removed the implicit default guard (``leakage_check`` -> typed
+    ``constraints``, absent = no checks), so silence would silently disable it.
+    splits_path-only configs are exempt: constraints are file-owned there — the
+    datamodule takes them from the loaded splits.json and ignores inline ones.
+    """
+    raw = yaml.safe_load((_CONFIGS / rel_path).read_text(encoding="utf-8"))
+    for key in keys:
+        raw = raw[key]
+    splits = DataSplitConfig.model_validate(raw)
+    assert splits.constraints == [
+        Constraint(kind=ConstraintKind.NO_SPLIT_OVERLAP, severity=severity)
+    ]
+
+
+def test_no_config_still_uses_leakage_check():
+    """`leakage_check` was removed in schemas 0.9.0 (extra=forbid); nothing may still say it."""
+    offenders = [
+        str(p.relative_to(_CONFIGS))
+        for p in sorted(_CONFIGS.rglob("*.yaml"))
+        if "leakage_check" in p.read_text(encoding="utf-8")
+    ]
+    assert not offenders, f"configs still using removed leakage_check: {offenders}"
 
 
 _TRAINRUN_DIR = _CONFIGS / "trainrun"
@@ -83,3 +146,31 @@ def test_trainrun_pipeline_references_resolve():
         assert pipeline.nodes, f"{trainrun_path.name}: referenced pipeline has no nodes"
         checked += 1
     assert checked >= 12  # 12 migrated Hydra configs + 2 extracted snapshots
+
+
+def test_trainrun_node_references_exist_in_pipeline():
+    """Trainrun node lists and the checkpoint monitor name real pipeline nodes.
+
+    Guards against a pipeline edit orphaning its trainrun: dropping a loss/metric
+    node from the pipeline (e.g. slimming a preset for inference) silently breaks
+    RestoreTrainRun for every trainrun that still names it.
+    """
+    checked = 0
+    for trainrun_path, ref in _string_pipeline_configs():
+        raw = yaml.safe_load(trainrun_path.read_text(encoding="utf-8"))
+        pipeline = yaml.safe_load(
+            (trainrun_path.parent / ref).resolve().read_text(encoding="utf-8")
+        )
+        node_names = {node["name"] for node in pipeline.get("nodes", [])}
+        for key in ("loss_nodes", "metric_nodes", "unfreeze_nodes"):
+            missing = set(raw.get(key) or []) - node_names
+            assert not missing, f"{trainrun_path.name}: {key} {sorted(missing)} not in {ref}"
+        checkpoint = ((raw.get("training") or {}).get("callbacks") or {}).get("checkpoint") or {}
+        monitor = checkpoint.get("monitor")
+        if monitor and "/" in monitor:
+            node = monitor.split("/", 1)[0]
+            assert node in node_names, (
+                f"{trainrun_path.name}: checkpoint monitor {monitor!r} names no node in {ref}"
+            )
+        checked += 1
+    assert checked >= 12

--- a/uv.lock
+++ b/uv.lock
@@ -811,8 +811,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "cuvis-ai-core", specifier = ">=0.11.2" },
-    { name = "cuvis-ai-schemas", extras = ["full"], specifier = ">=0.8.0" },
+    { name = "cuvis-ai-core", specifier = ">=0.12.1" },
+    { name = "cuvis-ai-schemas", extras = ["full"], specifier = ">=0.9.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.4.0" },
@@ -879,7 +879,7 @@ dev = [
 
 [[package]]
 name = "cuvis-ai-core"
-version = "0.11.2"
+version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -912,22 +912,22 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/6d/c3c8c437c962ce6600a002232c1a11476c7ba2094dad4958435d9dc9ba7b/cuvis_ai_core-0.11.2.tar.gz", hash = "sha256:2f04515845649a12f1c2680856c0bf9942cf0e3fb9e6cce6a987a7400cc50e53", size = 710108, upload-time = "2026-07-17T10:18:26.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ec/1527b46af651a0f5db9c9a55e794fba728877d4835daaf4a4785165bb1ca/cuvis_ai_core-0.12.1.tar.gz", hash = "sha256:626135256fdd583789c04cade6b6ae904641cae1b2334655494bf3cf4a2fcd96", size = 739871, upload-time = "2026-08-20T07:10:09.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/a0/d927329e7cc8948582d67d24c80cb85bf8dbe069163bf4dcafed41e0adba/cuvis_ai_core-0.11.2-py3-none-any.whl", hash = "sha256:4c33e3b7cc938ba8711b2e1829a54199104d4ff7598ab0f04c9f2a40028464bb", size = 230023, upload-time = "2026-07-17T10:18:25.404Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/6b90737584df06138fc5511e3424716a9e21593157a068d59a715e331817/cuvis_ai_core-0.12.1-py3-none-any.whl", hash = "sha256:850c32fd03ad8bcafee9139d9767eb247e917531bc07257b93b2108d92171283", size = 238139, upload-time = "2026-08-20T07:10:07.758Z" },
 ]
 
 [[package]]
 name = "cuvis-ai-schemas"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/82/d4ca62c7f288816ca551d62a443a709e9ced031194663f907ce459e2a7f2/cuvis_ai_schemas-0.8.0.tar.gz", hash = "sha256:2d05e696610ddf23ce4e313b5434cd1a43ec5d58c999643d22dbcdb04efac4fc", size = 248505, upload-time = "2026-07-14T11:48:52.356Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/a3/33a5615e4ca40b8c227dbfb34c7362bccf58723f1007c744535339eccbf3/cuvis_ai_schemas-0.9.0.tar.gz", hash = "sha256:c03f9fd0f2cddba0309a7336434417f8846db309f29c3cc67ceb8fedd542f6ab", size = 252510, upload-time = "2026-07-28T14:32:48.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/27/bf85fe21ce9dad1cd4649c611a2c16fa38f0a927b076e75b447d130b1c4c/cuvis_ai_schemas-0.8.0-py3-none-any.whl", hash = "sha256:1a378c4663de79f7b102a101e663296f05f0f40b6305ce369517924b38ff9d4d", size = 76506, upload-time = "2026-07-14T11:48:51.197Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d3/e6a169b41441a48d3cd59638d0f183d34d3ebf78e6b66c7e690c66b8c9cc/cuvis_ai_schemas-0.9.0-py3-none-any.whl", hash = "sha256:17fc61b890d49e67a283ad4db53f120052d562019b9117ac85d5e7e262ba61d7", size = 76682, upload-time = "2026-07-28T14:32:46.974Z" },
 ]
 
 [package.optional-dependencies]
@@ -3777,15 +3777,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Four changes, three commits:

1. **`cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml`** - the fix. `path: "../../.."` is replaced by a git tag pin:

   ```yaml
   name: cuvis_ai_builtin
   package_name: cuvis-ai
   repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
   tag: "v0.11.5"
   ```

   `package_name` is required: for a git source `resolve_plugin_sources` otherwise falls back to the manifest key, uv normalises that to `cuvis-ai-builtin`, and the install dies on uv's metadata name check.

2. **`tests/plugins/test_builtin_manifest_location_independent.py`** (new) - copies the manifest to another directory and requires the parsed source to be identical. Tests the invariant, not the specific source kind.

3. **`cuvis_ai/configs/pipeline/anomaly/dinomaly/dinomaly_cir.yaml`** - rewritten as an inference-only preset (`metadata.name: dinomaly_cir_lentils`) matching the published lentils checkpoint: two-stage decider (`image_threshold: 0.14`, `top_k_fraction: 0.001`), `running_warmup_frames: 0`, and the training-only nodes removed (loss bridge, both metric nodes, heatmap visualizer, TensorBoard monitor).

4. **`pyproject.toml` + `uv.lock`** - `[tool.uv.sources]` temporarily points `cuvis-ai-core` at the `fix/child-runtime-cuda-torch` branch (cuvis-ai-core PR #59), locked to `0.12.0.post2+g6ac3bf3a6`. Marked LOCAL ONLY in the file.

Items 3 and 4 are unrelated to the manifest fix and are flagged below.

## Why

`path: "../../.."` resolves against the manifest's own directory, so it means two different things:

| deployment | resolves to | buildable |
| --- | --- | --- |
| source checkout | `<checkout>` | yes |
| wheel install | `<site-packages>` | **no** |

The configs ship inside the wheel (`package-data: configs/**/*.yaml`), so a customer install always takes the second row, and it fails outright rather than degrading:

```
RuntimeProjectError: Local plugin 'cuvis_ai_builtin' at <site-packages> has no
pyproject.toml; the composer needs it to learn the package name.
```

A tag pin needs no path resolution and therefore cannot vary by deployment.

Rejected alternative: repoint the path at the package directory and ship `pyproject.toml` as package data. `version` is dynamic via setuptools-scm and needs a git repo, `packages.find` is relative to the project root so a build from `<site-packages>/cuvis_ai` would not contain `cuvis_ai`, and it needs a second doctored pyproject committed inside the package.

## Verified

- **Pre-fix repro** against a real non-editable install of this checkout: the shipped manifest resolved to `<site-packages>` and raised the error above.
- **Post-fix, both deployments** through the real loader: wheel install and dev checkout both yield `GitPluginSource(package_name=cuvis-ai, tag=v0.11.5, sha=d127e03f0910)`.
- **Real `compose_env`** with the wheel-installed manifest and a registry core (`cuvis-ai-core==0.12.0`, the clean-system shape): `uv.lock` gets `cuvis-ai 0.11.5` from `git ...?rev=d127e03f`, and the child interpreter imports `cuvis_ai 0.11.5` with `torch 2.11.0+cu128` and CUDA available. setuptools-scm resolves a clean `0.11.5` out of uv's git checkout, so the shallow-clone concern does not materialise.
- **`package_name` necessity** reproduced directly: without it uv reports `Package metadata name 'cuvis-ai' does not match given name 'cuvis-ai-builtin'`.
- **Tests**: `tests/plugins` + `tests/configs` = 41 passed, 13 skipped. The new regression test was confirmed to fail against the pre-fix manifest, with exactly the checkout-root vs site-packages divergence.

## Possible pitfalls

1. **Two commits in here must not merge as they stand.** The `cuvis-ai-core` git-branch source in `pyproject.toml` and the matching `uv.lock` entry are local development scaffolding for cuvis-ai-core PR #59. `[tool.uv.sources]` does not reach the built wheel's metadata, so a release would not ship the git URL - but CI syncs `--locked`, so main would fetch core from an unmerged branch, and the lock becomes unresolvable the moment that branch is deleted. Re-comment the line and relock before merge.
3. **Host/child version skew is now structural.** The pin is static, so a child can run a different cuvis-ai patch version than the host that composed it - and after this ships as 0.11.6 the child will still install v0.11.5, whose own floor is `cuvis-ai-core>=0.11.2`. The existing `plugin_pin_bump` workflow picks this manifest up now that it has `repo` + `tag`, so the pin tracks releases without manual edits. Exact parity needs a registry source kind in the manifest schema, which is a cross-repo change and not this PR.
4. **The child now needs git and reachable github.com** to build the builtin plugin. Other manifests are already git-sourced, so this is not a new class of requirement, but an offline or air-gapped install has no path to the builtin nodes at all.
5. **The child no longer gets `cuvis-ai` as an editable path member,** so it no longer inherits cuvis-ai's own `[tool.uv.sources]` cu128 index by accident. That accident is exactly what hid the CPU-torch bug on developer machines (ALL-6036, cuvis-ai-core PR #59). Removing the leak is only safe together with that change, which pins child torch explicitly.
6. **The regression test resolves its manifest relative to the CWD** (`Path("cuvis_ai/configs/plugins/...")`), so it passes under CI's repo-root invocation and fails from anywhere else. `Path(__file__).parents[2]` would make it location-independent, like the thing it tests.

## Out of scope, filed separately

Three manifests still carry local paths, two of them absolute developer paths: `detr.yaml` and `turbovec.yaml` point at `D:/code-repos/...`, `bytetrack.yaml` at a sibling checkout. They ship in the wheel and cannot resolve on any other machine. Same class of defect, tracked separately.
