### PR TITLE
Bump plugin manifest pins to uv-index-sweep releases; document child-env resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
 - Bumped the `cuvis_ai_builtin` manifest pin v0.11.5 -> v0.12.0 so composed child environments install the released cuvis-ai matching the host.
+- Bumped the plugin manifest pins to the uv-index-sweep releases: sam3 v0.3.1 -> v0.3.2, adaclip v0.3.0 -> v0.3.1, rtsam2 v0.2.0 -> v0.2.1, dinomaly v0.5.0 -> v0.6.1 (also picking up the 0.6.0 conformance release), cuvis_ai_dataloader v0.5.0 -> v0.5.1, deepeiou v0.2.1 -> v0.2.2, augment v0.4.0 -> v0.4.1, cuvis_ai_inspecscrap v0.2.2 -> v0.2.3. These releases clarify the plugins' `[tool.uv.sources]` / `[[tool.uv.index]]` tables as local-development-only: installs as a git dependency never read them, and composed child environments get their torch build from the host (cuvis-ai-core >= 0.12.1).
+- Documented dependency resolution in composed child environments in the plugin development guide: what a plugin can and cannot influence (dependencies and version floors yes, resolver configuration no, `extras` on data-module capabilities as the only manifest knob), how cuvis-ai-core 0.12.1 mirrors the host's torch build into the child, and the failure modes (no host torch, unrecognized or mixed local version tags, a plugin torch floor above the host).
 
 ## 0.12.0 - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.12.1 - 2026-08-20
 
-- **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
-- Bumped the `cuvis_ai_builtin` manifest pin v0.11.5 -> v0.12.0 so composed child environments install the released cuvis-ai matching the host.
 - Bumped the plugin manifest pins to the uv-index-sweep releases: sam3 v0.3.1 -> v0.3.2, adaclip v0.3.0 -> v0.3.1, rtsam2 v0.2.0 -> v0.2.1, dinomaly v0.5.0 -> v0.6.1 (also picking up the 0.6.0 conformance release), cuvis_ai_dataloader v0.5.0 -> v0.5.1, deepeiou v0.2.1 -> v0.2.2, augment v0.4.0 -> v0.4.1, cuvis_ai_inspecscrap v0.2.2 -> v0.2.3. These releases clarify the plugins' `[tool.uv.sources]` / `[[tool.uv.index]]` tables as local-development-only: installs as a git dependency never read them, and composed child environments get their torch build from the host (cuvis-ai-core >= 0.12.1).
 - Documented dependency resolution in composed child environments in the plugin development guide: what a plugin can and cannot influence (dependencies and version floors yes, resolver configuration no, `extras` on data-module capabilities as the only manifest knob), how cuvis-ai-core 0.12.1 mirrors the host's torch build into the child, and the failure modes (no host torch, unrecognized or mixed local version tags, a plugin torch floor above the host).
+- **Added `DiceLoss` and `CrossEntropyLoss` segmentation loss nodes.** Multiclass-capable soft Dice (with an `include_background` toggle) and cross-entropy over BHWC logits `[B,H,W,K]` with integer targets `[B,H,W]`, subclassing the existing `LossNode` base (train/val/test stages) and registered in `cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml`. Ports the two losses out of the cuvis-ai-unet plugin so it can drop its local copies.
+- Bumped the `cuvis_ai_builtin` manifest pin v0.11.5 -> v0.12.0 so composed child environments install the released cuvis-ai matching the host.
 
 ## 0.12.0 - 2026-08-20
 

--- a/cuvis_ai/configs/plugins/adaclip.yaml
+++ b/cuvis_ai/configs/plugins/adaclip.yaml
@@ -7,7 +7,7 @@
 name: adaclip
 # AdaCLIP-based anomaly detection with advanced band selection
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-adaclip.git"
-tag: "v0.3.0"
+tag: "v0.3.1"
 package_name: "cuvis-ai-adaclip"
 capabilities:
 - class_name: cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector

--- a/cuvis_ai/configs/plugins/augment.yaml
+++ b/cuvis_ai/configs/plugins/augment.yaml
@@ -8,7 +8,7 @@ name: augment
 # Local development override (optional):
 # path: "../../../cuvis-ai-augment"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
-tag: "v0.4.0"
+tag: "v0.4.1"
 package_name: "cuvis-ai-augment"
 capabilities:
 - class_name: cuvis_ai_augment.node.compose.AugmentationCompose

--- a/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.5.0"
+tag: "v0.5.1"
 package_name: cuvis-ai-dataloader
 capabilities:
   - class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule

--- a/cuvis_ai/configs/plugins/cuvis_ai_inspecscrap.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_inspecscrap.yaml
@@ -4,7 +4,7 @@
 # Generic colourise/overlay/cleanup viz nodes live in the cuvis-ai node catalog, not here.
 name: cuvis_ai_inspecscrap
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-inspecscrap.git"
-tag: "v0.2.2"
+tag: "v0.2.3"
 package_name: cuvis-ai-inspecscrap
 capabilities:
   - { class_name: cuvis_ai_inspecscrap.node.data.TiffDataNode,                          category: source,    tags: [hyperspectral] }

--- a/cuvis_ai/configs/plugins/deepeiou.yaml
+++ b/cuvis_ai/configs/plugins/deepeiou.yaml
@@ -7,7 +7,7 @@
 name: deepeiou
 # path: "../../../../cuvis-ai-deepeiou/deepeiou-init"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-deepeiou.git"
-tag: "v0.2.1"
+tag: "v0.2.2"
 package_name: "cuvis-ai-deepeiou"
 capabilities:
 - class_name: cuvis_ai_deepeiou.node.DeepEIoUTrack

--- a/cuvis_ai/configs/plugins/dinomaly.yaml
+++ b/cuvis_ai/configs/plugins/dinomaly.yaml
@@ -8,7 +8,7 @@ name: dinomaly
 # Local development override (optional):
 # path: "../../../cuvis-ai-dinomaly"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly.git"
-tag: "v0.5.0"
+tag: "v0.6.1"
 package_name: "cuvis-ai-dinomaly"
 capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector

--- a/cuvis_ai/configs/plugins/rtsam2.yaml
+++ b/cuvis_ai/configs/plugins/rtsam2.yaml
@@ -10,7 +10,7 @@ name: rtsam2
 # For local development against a checkout, comment the repo/tag pin and use:
 # path: "D:/code-repos/cuvis-ai-rtsam2/cuvis-ai-rtsam2"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-rtsam2.git"
-tag: "v0.2.0"
+tag: "v0.2.1"
 package_name: "cuvis-ai-rtsam2"
 capabilities:
 - class_name: cuvis_ai_rtsam2.node.rtsam2_streaming_propagation.RTSAM2BboxPropagation

--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.3.1"  # streaming-propagation hardening: needs-seed recovery, pinned prompt-frame features
+tag: "v0.3.2"  # torch uv-index tables clarified as local-dev-only
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation

--- a/docs/reference/plugin-development/guide.md
+++ b/docs/reference/plugin-development/guide.md
@@ -69,6 +69,19 @@ Each `capabilities` entry needs at least `class_name` (a fully-qualified path); 
 palette metadata (`category`, `tags`, `icon_svg`, `input_specs`, `output_specs`, `doc_summary`).
 See [Plugin System Overview](overview.md).
 
+## Dependency resolution in composed child environments
+
+When the orchestrated gRPC server runs a pipeline, it composes an isolated child
+environment from the declared plugin manifests (see
+[Cache and Isolation](overview.md#cache-and-isolation)). Dependency resolution in
+that environment follows a few rules worth knowing before you publish a plugin:
+
+- **Plugins cannot influence resolver configuration.** The composer owns the child environment's `pyproject.toml`; a plugin contributes only its package as a requirement. Its declared dependencies and version floors still constrain what resolves, but it cannot add indexes or sources. The only manifest-level knob is `extras` on `kind: data_module` capabilities, which selects the pip extras installed for a run that uses that data module.
+- **Torch mirrors the host.** As of cuvis-ai-core 0.12.1 the composed child environment mirrors the composing host's installed torch build: the exact `torch` / `torchvision` versions are pinned, and the matching PyTorch wheel index (`cpu`, `cuNNN`, `rocm`, or `xpu`) is emitted with `explicit = true`, so the child resolves the same accelerator build the host runs.
+- **Host edge cases.** A host with no torch installed leaves children resolving transitive torch from PyPI (CPU wheels on Windows). A host torch whose local version tag is unrecognized, or mixed across `torch` and `torchvision`, gets its versions pinned without an index, so the child's resolution fails with a no-candidates error; fix the host environment in that case.
+- **Floors above the host fail fast.** A plugin whose torch floor is above the host's installed torch fails composition outright. Keep torch floors as low as the plugin genuinely needs.
+- **`[tool.uv.sources]` and `[[tool.uv.index]]` do not travel.** Those tables in a plugin repo's `pyproject.toml` apply only to that repo's own development venv, where the plugin is the resolution root. Installs as a git or registry dependency, including composed child environments, never read them.
+
 ## Verification
 
 Use `uv` for local validation:

--- a/docs/reference/plugin-development/overview.md
+++ b/docs/reference/plugin-development/overview.md
@@ -85,6 +85,7 @@ shown above.
 - In-process registration imports plugins from the active environment; install them with the `provision` CLI, `uv pip install`, or an editable `[tool.uv.sources]` checkout.
 - The orchestrated server composes an isolated venv per plugin set, cached by a content hash of its generated `pyproject.toml`, so identical plugin sets reuse the same child environment.
 - Plugin nodes are stored per `NodeRegistry` instance, so one session can register plugins without affecting another.
+- How the composed environment resolves plugin dependencies, including how it mirrors the host's torch build, is covered in [Dependency resolution in composed child environments](guide.md#dependency-resolution-in-composed-child-environments).
 
 ## Loading multiple plugins
 


### PR DESCRIPTION
Bumps every external plugin manifest pin to the uv-index-sweep release of its repo and documents how dependency resolution actually works in composed child environments.

Pin bumps (cuvis_ai/configs/plugins/):

- sam3 v0.3.1 -> v0.3.2
- adaclip v0.3.0 -> v0.3.1
- rtsam2 v0.2.0 -> v0.2.1
- dinomaly v0.5.0 -> v0.6.1 (also picks up the 0.6.0 conformance release)
- cuvis_ai_dataloader v0.5.0 -> v0.5.1
- deepeiou v0.2.1 -> v0.2.2
- augment v0.4.0 -> v0.4.1
- cuvis_ai_inspecscrap v0.2.2 -> v0.2.3

Docs: new "Dependency resolution in composed child environments" subsection in the plugin development guide, cross-linked from the plugin overview's Cache and Isolation section. It covers what a plugin can and cannot influence (dependencies and version floors yes, resolver configuration no; `extras` on data-module capabilities is the only manifest knob), how cuvis-ai-core 0.12.1 mirrors the host's installed torch build into the child (exact torch/torchvision pins plus the matching PyTorch wheel index emitted explicit), and the failure modes (no host torch, unrecognized or mixed local version tags, a plugin torch floor above the host).

Why: the `[tool.uv.sources]` / `[[tool.uv.index]]` tables in the plugin repos were dead weight for dependency installs; they only ever applied to each repo's own development venv, never to installs as a git dependency. The swept releases mark them as local-dev-only, and since cuvis-ai-core 0.12.1 the composed child environments get their torch build mirrored from the host anyway.

CHANGELOG updated under Unreleased.
