### PR TITLE
feat(plugins): rtsam2 v0.3.0 with RTSAM2PointExpansion capability and pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Security: refreshed the `pip` lock to 26.2 (PYSEC-2026-3721, doubly-encoded index URLs allowing arbitrary file placement).
 - Bumped the rtsam2 plugin manifest pin v0.2.1 -> v0.3.0 and added its new `RTSAM2PointExpansion` capability: interactive single-frame point expansion (positive/negative clicks to one object mask), port-compatible with `SAM3PointExpansion` and re-promptable in place (every clicked frame re-seeds the predictor, so updated point sets refresh the mask deterministically; runs on CPU-only machines too). Added the matching `rtsam2_point_expansion.yaml` / `rtsam2_point_expansion_view.yaml` pipeline presets.
 - Bumped the `cuvis_ai_builtin` manifest pin v0.12.0 -> v0.12.1 so composed child environments install the released cuvis-ai matching the host.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bumped the rtsam2 plugin manifest pin v0.2.1 -> v0.3.0 and added its new `RTSAM2PointExpansion` capability: interactive single-frame point expansion (positive/negative clicks to one object mask), port-compatible with `SAM3PointExpansion` and re-promptable in place (every clicked frame re-seeds the predictor, so updated point sets refresh the mask deterministically; runs on CPU-only machines too). Added the matching `rtsam2_point_expansion.yaml` / `rtsam2_point_expansion_view.yaml` pipeline presets.
 - Bumped the `cuvis_ai_builtin` manifest pin v0.12.0 -> v0.12.1 so composed child environments install the released cuvis-ai matching the host.
 
 ## 0.12.1 - 2026-08-20

--- a/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion.yaml
+++ b/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion.yaml
@@ -1,0 +1,34 @@
+metadata:
+  name: RTSAM2_Point_Expansion
+  description: RTSAM2 single-frame interactive point expansion (positive/negative points to one
+    object mask) with CU3S source-domain frame mapping
+  tags:
+  - segmentation
+  - rtsam2
+  - point-prompt
+  - rgb
+  author: cuvis.ai
+plugins:
+- cuvis_ai_builtin
+- rtsam2
+nodes:
+- name: cu3s_data
+  class_name: cuvis_ai.node.data.CU3SDataNode
+  hparams: {}
+- name: true_rgb
+  class_name: cuvis_ai.node.channel_selector.CIETristimulusRGBSelector
+  hparams: {}
+- name: rtsam2_point_expansion
+  class_name: cuvis_ai_rtsam2.node.rtsam2_point_expansion.RTSAM2PointExpansion
+  hparams:
+    model_type: efficienttam
+    # model_dir: checkpoints  # absolute path, or relative to the rtsam2 repo root
+connections:
+- source: cu3s_data.outputs.cube
+  target: true_rgb.inputs.cube
+- source: cu3s_data.outputs.wavelengths
+  target: true_rgb.inputs.wavelengths
+- source: true_rgb.outputs.rgb_image
+  target: rtsam2_point_expansion.inputs.rgb_image
+- source: cu3s_data.outputs.mesu_index
+  target: rtsam2_point_expansion.inputs.frame_id

--- a/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_view.yaml
+++ b/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_view.yaml
@@ -1,0 +1,23 @@
+metadata:
+  name: RTSAM2_Point_Expansion_View
+  description: RTSAM2 single-frame interactive point expansion driven by the host-rendered view
+    frame. The host supplies the displayed RGB/CIR/SWIR false-color image as rgb_image (no
+    overlays) plus the positive/negative points and the source frame_id; the hyperspectral cube
+    never leaves the host. Every clicked frame re-seeds the predictor, so updated point sets
+    refresh the mask in place (no session reset needed between clicks).
+  tags:
+  - segmentation
+  - rtsam2
+  - point-prompt
+  - rgb
+  - expansion
+  author: cuvis.ai
+plugins:
+- rtsam2
+nodes:
+- name: rtsam2_point_expansion
+  class_name: cuvis_ai_rtsam2.node.rtsam2_point_expansion.RTSAM2PointExpansion
+  hparams:
+    model_type: efficienttam
+    # model_dir: checkpoints  # absolute path, or relative to the rtsam2 repo root
+connections: []

--- a/cuvis_ai/configs/plugins/rtsam2.yaml
+++ b/cuvis_ai/configs/plugins/rtsam2.yaml
@@ -10,7 +10,7 @@ name: rtsam2
 # For local development against a checkout, comment the repo/tag pin and use:
 # path: "D:/code-repos/cuvis-ai-rtsam2/cuvis-ai-rtsam2"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-rtsam2.git"
-tag: "v0.2.1"
+tag: "v0.3.0"
 package_name: "cuvis-ai-rtsam2"
 capabilities:
 - class_name: cuvis_ai_rtsam2.node.rtsam2_streaming_propagation.RTSAM2BboxPropagation
@@ -87,3 +87,40 @@ capabilities:
       optional: false
       description: ''
   doc_summary: RTSAM2 propagation with runtime label-map prompts.
+- class_name: cuvis_ai_rtsam2.node.rtsam2_point_expansion.RTSAM2PointExpansion
+  category: model
+  tags: [batched, image, inference, keypoints, learnable, mask, rgb, segmentation, torch]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#4E7BD4\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <circle cx=\"14\" cy=\"20\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"44\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"16\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"48\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"26\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"38\" r=\"3\"/>\n  <path d=\"M17 20l12-4M17 32l12-16M17 44l12-28\"/>\n  <path d=\"M17 20l12 12M17 32l12 0M17 44l12-12\"/>\n  <path d=\"M17 20l12 28M17 32l12 16M17 44l12 4\"/>\n  <path d=\"M35 16l12 10M35 32l12-6M35 48l12-22\"/>\n  <path d=\"M35 16l12 22M35 32l12 6M35 48l12-10\"/>\n</svg>\n"
+  input_specs:
+    rgb_image:
+      dtype: float32
+      shape: [1, -1, -1, 3]
+      optional: false
+      description: RGB frame [1,H,W,3] in float32 with values in [0, 1].
+    points:
+      dtype: ''
+      shape: []
+      optional: true
+      description: Optional per-frame list of point prompt dicts with keys element_id, x, y, type (type in {positive, negative, neutral}). Positive=object, negative=background.
+    frame_id:
+      dtype: int64
+      shape: [1]
+      optional: true
+      description: Optional source frame index [1]; accepted for contract parity, unused.
+  output_specs:
+    mask:
+      dtype: int32
+      shape: [1, -1, -1]
+      optional: false
+      description: ''
+    object_ids:
+      dtype: int64
+      shape: [1, -1]
+      optional: false
+      description: ''
+    detection_scores:
+      dtype: float32
+      shape: [1, -1]
+      optional: false
+      description: ''
+  doc_summary: Expand positive/negative click points into one object mask on a single frame.

--- a/docs/reference/plugin-development/overview.md
+++ b/docs/reference/plugin-development/overview.md
@@ -108,7 +108,7 @@ All official plugins ship as git-tagged releases (bare name resolves to the matc
 - [`cuvis_ai_inspecscrap.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/cuvis_ai_inspecscrap.yaml): metal-scrap inspection nodes, pinned to `v0.2.2`
 - [`deepeiou.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/deepeiou.yaml): DeepEIoU tracking plugin, pinned to `v0.2.1`
 - [`dinomaly.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/dinomaly.yaml): Dinomaly anomaly detection, pinned to `v0.4.1`
-- [`rtsam2.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/rtsam2.yaml): real-time SAM 2 / EfficientTAM plugin, pinned to `v0.2.0`
+- [`rtsam2.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/rtsam2.yaml): real-time SAM 2 / EfficientTAM plugin, pinned to `v0.3.0`
 - [`sam3.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/sam3.yaml): SAM 3.1 tracking plugin, pinned to `v0.2.1`
 - [`trackeval.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/trackeval.yaml): tracking-metric plugin, pinned to `v0.1.4`
 - [`ultralytics.yaml`](https://github.com/cubert-hyperspectral/cuvis-ai/blob/main/cuvis_ai/configs/plugins/ultralytics.yaml): Ultralytics YOLO26 plugin, pinned to `v0.1.4`

--- a/uv.lock
+++ b/uv.lock
@@ -3323,11 +3323,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Integrates the rtsam2 v0.3.0 release: bumps the manifest pin v0.2.1 -> v0.3.0, adds the new
`RTSAM2PointExpansion` capability (interactive single-frame point expansion, port-compatible
with `SAM3PointExpansion`), and ships the two matching pipeline presets.

## Changes

- `cuvis_ai/configs/plugins/rtsam2.yaml`: tag bump + capability block generated with
  cuvis-ai-core's `emit_metadata` (`--check` reports in sync; `frame_id` documented as
  "accepted for contract parity, unused" - the rtsam2 node re-seeds per click instead of
  caching embeddings).
- `cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion.yaml`: CU3S + tristimulus RGB +
  node, `mesu_index -> frame_id`, `points` left unconnected by design (host injects clicks).
- `cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_view.yaml`: single-node
  host-driven preset; unlike the propagation view pipelines, updated point sets refresh the
  mask in place (no session reset between clicks).
- `docs/reference/plugin-development/overview.md`: fix the stale rtsam2 pin line.

## Verification

- Pre-tag dry run against the release branch via a local-path manifest: `restore-pipeline`
  on both presets over the Lentils cu3s (14 frames, empty-points path), plus a `PointPrompt`
  driver pipeline proving a real click yields a mask on the clicked frame (area 908 px,
  score 0.992) and empty outputs elsewhere.
- `uv run pytest -m "not slow and not gpu"`: 1295 passed.
- `uv run mkdocs build --strict`: clean.

Release context: cubert-hyperspectral/cuvis-ai-rtsam2 v0.3.0
(`cubert-hyperspectral/cuvis-ai-rtsam2#5`).
