### PR TITLE
CocoTrackMaskWriter defaults to image-keyed COCO; reader gains image-dialect masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+- **Breaking: `CocoTrackMaskWriter` now defaults to standard image-keyed COCO output.**
+  The mask-tracking writer previously emitted a YouTube-VIS-shaped track dialect
+  (top-level `videos`, one annotation per track with per-frame parallel arrays, no
+  `image_id`) that pycocotools — and with it the training-side `CocoLabeler`, plus
+  `cuvis-ai-trackeval`, the occlusion nodes, and `append_tracking_metrics` — cannot read.
+  The default output is now standard COCO: per-frame `images` records plus one annotation
+  per (track, frame) carrying an RLE `segmentation`, `bbox`/`area`, `iscrowd: 1`, and
+  additive `score`/`track_id` keys, with per-frame image dimensions. All pipeline configs
+  that wire the writer inherit the new default. The legacy shape stays available as an
+  explicit opt-in via the new `dialect` parameter (`dialect: video`); files already on
+  disk keep working everywhere (`TrackingResultsReader`, the prompt nodes, and
+  cuvis-ai-dataloader >= 0.6.0 read both dialects).
+- `TrackingResultsReader`: the image-dialect (`coco_bbox`) path now also reconstructs the
+  `mask` label map and `object_ids` from per-annotation RLE `segmentation` dicts (pixel
+  value = `track_id`, annotation id when track_id is missing or negative; overlaps painted
+  in ascending annotation-id order; RLE dimensions validated against the image record), and
+  derives `bbox` from the RLE for bbox-less annotations. Pure bbox files behave exactly as
+  before.
+- Bumped the cuvis_ai_dataloader manifest pin v0.5.1 -> v0.6.0: `CocoLabeler` reads both
+  COCO label dialects (legacy track-dialect files convert in memory) and rasterizes
+  standard RLE-object segmentations, so tracked-session annotations train end to end.
 - Security: refreshed the `pip` lock to 26.2 (PYSEC-2026-3721, doubly-encoded index URLs allowing arbitrary file placement).
 - Bumped the rtsam2 plugin manifest pin v0.2.1 -> v0.3.0 and added its new `RTSAM2PointExpansion` capability: interactive single-frame point expansion (positive/negative clicks to one object mask), port-compatible with `SAM3PointExpansion` and re-promptable in place (every clicked frame re-seeds the predictor, so updated point sets refresh the mask deterministically; runs on CPU-only machines too). Added the matching `rtsam2_point_expansion.yaml` / `rtsam2_point_expansion_view.yaml` pipeline presets.
 - Bumped the `cuvis_ai_builtin` manifest pin v0.12.0 -> v0.12.1 so composed child environments install the released cuvis-ai matching the host.

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -1529,7 +1529,7 @@ capabilities:
       shape: [-1]
       optional: true
       description: Optional UTF-8 JSON bytes mapping category IDs to category names.
-  doc_summary: Write mask tracking outputs into video_coco JSON.
+  doc_summary: Write mask tracking outputs as COCO JSON in one of two dialects.
 - class_name: cuvis_ai.node.labels.BinaryAnomalyLabelMapper
   category: transform
   tags: [anomaly, mask, numpy, postprocessing]

--- a/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.5.1"
+tag: "v0.6.0"
 package_name: cuvis-ai-dataloader
 capabilities:
   - class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule

--- a/cuvis_ai/node/json_file.py
+++ b/cuvis_ai/node/json_file.py
@@ -177,7 +177,15 @@ class _BaseCocoTrackWriter(_BaseJsonWriterNode):
 
 
 class CocoTrackMaskWriter(_BaseCocoTrackWriter):
-    """Write mask tracking outputs into video_coco JSON."""
+    """Write mask tracking outputs as COCO JSON in one of two dialects.
+
+    The default ``dialect="image"`` emits standard image-keyed COCO: per-frame ``images``
+    records plus one annotation per (track, frame) carrying an RLE ``segmentation``,
+    ``bbox``/``area``, and additive ``track_id``/``score`` keys — readable by pycocotools
+    and every image-keyed COCO consumer. ``dialect="video"`` emits the legacy
+    YouTube-VIS-shaped track dialect (top-level ``videos``, one annotation per track with
+    per-frame parallel arrays) for external video-COCO tooling.
+    """
 
     _category = NodeCategory.SINK
     _tags = frozenset({NodeTag.METADATA, NodeTag.MASK, NodeTag.TRACKING})
@@ -220,15 +228,19 @@ class CocoTrackMaskWriter(_BaseCocoTrackWriter):
     def __init__(
         self,
         output_json_path: str,
+        dialect: str = "image",
         default_category_name: str = "object",
         write_empty_frames: bool = True,
         atomic_write: bool = True,
         flush_interval: int = 0,
         **kwargs: Any,
     ) -> None:
+        if dialect not in {"image", "video"}:
+            raise ValueError("dialect must be one of {'image', 'video'}.")
         if not default_category_name:
             raise ValueError("default_category_name must be a non-empty string.")
 
+        self.dialect = dialect
         self.default_category_name = default_category_name
         self.write_empty_frames = bool(write_empty_frames)
         self._frame_hw_by_id: dict[int, tuple[int, int]] = {}
@@ -243,6 +255,7 @@ class CocoTrackMaskWriter(_BaseCocoTrackWriter):
             output_json_path=output_json_path,
             atomic_write=atomic_write,
             flush_interval=flush_interval,
+            dialect=dialect,
             default_category_name=default_category_name,
             write_empty_frames=write_empty_frames,
             **kwargs,
@@ -405,8 +418,64 @@ class CocoTrackMaskWriter(_BaseCocoTrackWriter):
         self._mark_dirty_and_maybe_flush()
         return {}
 
-    def _flush_json(self) -> None:
-        """Emit the accumulated mask tracks in video-COCO format."""
+    def _categories_payload(self) -> list[dict[str, Any]]:
+        """Category records shared by both dialects (default entry when none were seen)."""
+        categories = [
+            {"id": int(category_id), "name": name}
+            for category_id, name in sorted(self._category_id_to_name.items())
+        ]
+        if not categories:
+            categories = [{"id": 1, "name": self.default_category_name}]
+        return categories
+
+    def _image_dialect_payload(self) -> dict[str, Any]:
+        """Standard image-keyed COCO: per-frame images, one annotation per (track, frame)."""
+        frame_indices = sorted(self._frame_hw_by_id.keys())
+        images = [
+            {
+                "id": int(fid),
+                "file_name": f"frame_{int(fid):06d}",
+                "height": int(self._frame_hw_by_id[fid][0]),
+                "width": int(self._frame_hw_by_id[fid][1]),
+            }
+            for fid in frame_indices
+        ]
+
+        annotations = []
+        ann_id = 1
+        for track_id in sorted(self._track_segmentations.keys()):
+            per_frame_seg = self._track_segmentations.get(track_id, {})
+            per_frame_scores = self._track_scores.get(track_id, {})
+            per_frame_bboxes = self._track_bboxes.get(track_id, {})
+            per_frame_areas = self._track_areas.get(track_id, {})
+            for fid in frame_indices:
+                seg = per_frame_seg.get(fid)
+                if seg is None:
+                    continue
+                annotations.append(
+                    {
+                        "id": ann_id,
+                        "image_id": int(fid),
+                        "category_id": int(self._track_category_ids.get(track_id, 1)),
+                        "segmentation": seg,
+                        "bbox": per_frame_bboxes.get(fid),
+                        "area": float(per_frame_areas.get(fid, 0.0)),
+                        "iscrowd": 1,
+                        "score": float(per_frame_scores.get(fid, 0.0)),
+                        "track_id": int(track_id),
+                    }
+                )
+                ann_id += 1
+
+        return {
+            "info": {"description": "Mask tracking results", "version": "1.0"},
+            "images": images,
+            "annotations": annotations,
+            "categories": self._categories_payload(),
+        }
+
+    def _video_dialect_payload(self) -> dict[str, Any]:
+        """Legacy track dialect: one video record, per-track parallel arrays."""
         frame_indices = sorted(self._frame_hw_by_id.keys())
         first_frame = frame_indices[0] if frame_indices else 0
         frame_h, frame_w = self._frame_hw_by_id.get(first_frame, (0, 0))
@@ -449,14 +518,7 @@ class CocoTrackMaskWriter(_BaseCocoTrackWriter):
             )
             ann_id += 1
 
-        categories = [
-            {"id": int(category_id), "name": name}
-            for category_id, name in sorted(self._category_id_to_name.items())
-        ]
-        if not categories:
-            categories = [{"id": 1, "name": self.default_category_name}]
-
-        payload = {
+        return {
             "info": {"description": "Mask tracking results", "version": "1.0"},
             "videos": [
                 {
@@ -470,8 +532,15 @@ class CocoTrackMaskWriter(_BaseCocoTrackWriter):
                 }
             ],
             "annotations": annotations,
-            "categories": categories,
+            "categories": self._categories_payload(),
         }
+
+    def _flush_json(self) -> None:
+        """Emit the accumulated mask tracks in the configured COCO dialect."""
+        if self.dialect == "video":
+            payload = self._video_dialect_payload()
+        else:
+            payload = self._image_dialect_payload()
         self._write_payload(payload)
         self._finish_flush()
 
@@ -874,12 +943,16 @@ class TrackingResultsReader(Node):
 
     Supports two JSON formats:
 
-    1. **COCO bbox tracking** — ``images`` + ``annotations`` with ``bbox`` and
-       ``track_id`` fields.  Emits ``bboxes``, ``category_ids``, ``confidences``,
-       ``track_ids``.
+    1. **COCO image dialect** (``coco_bbox``) — ``images`` + ``annotations`` with
+       ``bbox`` and/or RLE-dict ``segmentation`` fields plus additive ``track_id``.
+       Emits ``bboxes``, ``category_ids``, ``confidences``, ``track_ids``; when any
+       annotation carries a ``segmentation``, also emits the ``mask`` label map
+       (pixel value = ``track_id``, annotation id when track_id is missing/negative;
+       overlaps painted in ascending annotation-id order) and ``object_ids``.
 
-    2. **Video COCO** — ``videos`` + ``annotations`` with ``segmentations``
-       list of RLE dicts.  Emits ``mask`` label map and ``object_ids``.
+    2. **Video COCO** (``video_coco``) — ``videos`` + ``annotations`` with
+       ``segmentations`` list of RLE dicts.  Emits ``mask`` label map and
+       ``object_ids``.
 
     Optional outputs are ``None`` when the format doesn't provide them.
 
@@ -999,12 +1072,23 @@ class TrackingResultsReader(Node):
 
     # -- Format-specific init --------------------------------------------------
 
+    @staticmethod
+    def _annotation_rle(ann: dict) -> dict | None:
+        """Return the annotation's RLE-dict ``segmentation`` or ``None``."""
+        seg = ann.get("segmentation")
+        if isinstance(seg, dict) and "counts" in seg:
+            return seg
+        return None
+
     def _init_coco_bbox(self, data: dict) -> None:
-        """Index COCO bbox annotations by image ID for per-frame lookup."""
+        """Index image-dialect annotations by image ID (bboxes plus optional RLE masks)."""
         self._images = {int(img["id"]): img for img in data.get("images", [])}
         self._annotations_by_img: dict[int, list[dict]] = {}
+        self._has_segmentations = False
         for ann in data.get("annotations", []):
             self._annotations_by_img.setdefault(int(ann["image_id"]), []).append(ann)
+            if self._annotation_rle(ann) is not None:
+                self._has_segmentations = True
         self._frame_ids = sorted(self._images.keys())
 
     def _init_video_coco(self, data: dict) -> None:
@@ -1107,8 +1191,18 @@ class TrackingResultsReader(Node):
         anns = self._annotations_by_img.get(frame_id, [])
 
         bboxes, cats, scores, tids = [], [], [], []
+        mask_entries: list[tuple[int, int, dict]] = []  # (ann_id, label, rle)
         for ann in anns:
-            x, y, w, h = ann["bbox"]
+            rle = self._annotation_rle(ann)
+            bbox = ann.get("bbox")
+            if bbox is None and rle is not None:
+                bbox = coco_rle_to_bbox(rle)
+            if bbox is None:
+                raise ValueError(
+                    f"Annotation {ann.get('id')} in {self.json_path} carries neither a "
+                    "bbox nor an RLE segmentation."
+                )
+            x, y, w, h = bbox
             bboxes.append([x, y, x + w, y + h])
             category_id = ann.get("category_id", 0)
             score = ann.get("score", 0.0)
@@ -1116,6 +1210,11 @@ class TrackingResultsReader(Node):
             cats.append(int(category_id) if category_id is not None else 0)
             scores.append(float(score) if score is not None else 0.0)
             tids.append(int(track_id) if track_id is not None else -1)
+            if rle is not None:
+                ann_id = int(ann.get("id", 0))
+                raw_tid = ann.get("track_id")
+                label = int(raw_tid) if raw_tid is not None and int(raw_tid) >= 0 else ann_id
+                mask_entries.append((ann_id, label, rle))
 
         n = len(bboxes)
         bboxes_t = (
@@ -1138,6 +1237,11 @@ class TrackingResultsReader(Node):
         h_px = int(img.get("height", 0))
         w_px = int(img.get("width", 0))
 
+        if self._has_segmentations and h_px > 0 and w_px > 0:
+            mask_t, oids_t = self._mask_entries_to_label_map(mask_entries, h_px, w_px)
+        else:
+            mask_t, oids_t = empty_mask, empty_oids
+
         return {
             "frame_id": torch.tensor([frame_id], dtype=torch.int64),
             "orig_hw": torch.tensor([[h_px, w_px]], dtype=torch.int64),
@@ -1145,9 +1249,45 @@ class TrackingResultsReader(Node):
             "category_ids": cats_t,
             "confidences": scores_t,
             "track_ids": tids_t,
-            "mask": empty_mask,
-            "object_ids": empty_oids,
+            "mask": mask_t,
+            "object_ids": oids_t,
         }
+
+    def _mask_entries_to_label_map(
+        self,
+        entries: list[tuple[int, int, dict]],
+        h: int,
+        w: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Paint image-dialect RLEs into a label map in ascending annotation-id order.
+
+        The painted value is the annotation's ``track_id`` (annotation id when track_id
+        is missing or negative), so on overlap the highest annotation id wins
+        deterministically. RLE dimensions must match the frame's image record.
+        """
+        label_map = np.zeros((h, w), dtype=np.int32)
+        labels: set[int] = set()
+        for ann_id, label, rle in sorted(entries, key=lambda entry: entry[0]):
+            if not -(2**31) <= label < 2**31:
+                raise ValueError(
+                    f"Annotation {ann_id} in {self.json_path}: label {label} does not fit int32."
+                )
+            binary = coco_rle_decode(rle)
+            if binary.shape != (h, w):
+                raise ValueError(
+                    f"Annotation {ann_id} in {self.json_path}: RLE size "
+                    f"{tuple(binary.shape)} disagrees with the image record ({h}, {w})."
+                )
+            label_map[binary > 0] = label
+            labels.add(label)
+
+        mask_t = torch.from_numpy(label_map).unsqueeze(0)
+        oids_t = (
+            torch.tensor([sorted(labels)], dtype=torch.int64)
+            if labels
+            else torch.empty((1, 0), dtype=torch.int64)
+        )
+        return mask_t, oids_t
 
     def _rles_to_label_map(
         self,

--- a/tests/node/test_tracking_coco_json.py
+++ b/tests/node/test_tracking_coco_json.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
 from cuvis_ai.node.json_file import CocoTrackMaskWriter
+from cuvis_ai_core.data.rle import coco_rle_encode, coco_rle_to_bbox
 
 
 def _build_inputs(
@@ -39,10 +41,401 @@ def _read_json(path: Path) -> dict:
         return json.load(handle)
 
 
+# ---------------------------------------------------------------------------
+# Image dialect (default)
+# ---------------------------------------------------------------------------
+
+
 def test_tracking_coco_json_writes_valid_json_after_each_frame(tmp_path: Path) -> None:
     json_path = tmp_path / "tracking_results.json"
     node = CocoTrackMaskWriter(
         output_json_path=str(json_path), default_category_name="person", flush_interval=1
+    )
+
+    frames = (
+        _build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.5],
+        ),
+        _build_inputs(
+            frame_idx=1,
+            mask_2d=torch.zeros((2, 2), dtype=torch.int32),
+            object_ids=[],
+            detection_scores=[],
+        ),
+        _build_inputs(
+            frame_idx=2,
+            mask_2d=torch.tensor([[0, 2], [2, 2]], dtype=torch.int32),
+            object_ids=[2],
+            detection_scores=[0.25],
+        ),
+    )
+
+    for frame in frames:
+        node.forward(**frame)
+        parsed = _read_json(json_path)
+        assert set(parsed.keys()) == {"info", "images", "annotations", "categories"}
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert [img["id"] for img in parsed["images"]] == [0, 1, 2]
+    for img in parsed["images"]:
+        assert img["file_name"] == f"frame_{img['id']:06d}"
+        assert img["height"] == 2 and img["width"] == 2
+    assert len(parsed["annotations"]) == 2
+    assert parsed["categories"] == [{"id": 1, "name": "person"}]
+    for ann in parsed["annotations"]:
+        assert set(ann.keys()) == {
+            "id",
+            "image_id",
+            "category_id",
+            "segmentation",
+            "bbox",
+            "area",
+            "iscrowd",
+            "score",
+            "track_id",
+        }
+        assert isinstance(ann["segmentation"], dict)
+        assert ann["iscrowd"] == 1
+    annotations_by_track = {ann["track_id"]: ann for ann in parsed["annotations"]}
+    assert annotations_by_track[1]["image_id"] == 0
+    assert annotations_by_track[1]["score"] == 0.5
+    assert annotations_by_track[2]["image_id"] == 2
+    assert annotations_by_track[2]["area"] == 3.0
+
+
+def test_tracking_coco_json_replaces_existing_frame_idempotently(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=4,
+            mask_2d=torch.tensor([[1, 1], [0, 0]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.25],
+        )
+    )
+    node.forward(
+        **_build_inputs(
+            frame_idx=4,
+            mask_2d=torch.tensor([[1, 1], [0, 0]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.75],
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert [img["id"] for img in parsed["images"]] == [4]
+    assert len(parsed["annotations"]) == 1
+    assert parsed["annotations"][0]["score"] == 0.75
+
+
+def test_tracking_coco_json_writes_empty_frame_entry(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=7,
+            mask_2d=torch.zeros((3, 4), dtype=torch.int32),
+            object_ids=[],
+            detection_scores=[],
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert parsed["images"] == [{"id": 7, "file_name": "frame_000007", "height": 3, "width": 4}]
+    assert parsed["annotations"] == []
+
+
+def test_tracking_coco_json_records_per_frame_dimensions(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.5],
+        )
+    )
+    node.forward(
+        **_build_inputs(
+            frame_idx=1,
+            mask_2d=torch.zeros((3, 4), dtype=torch.int32),
+            object_ids=[],
+            detection_scores=[],
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    dims = {img["id"]: (img["height"], img["width"]) for img in parsed["images"]}
+    assert dims == {0: (2, 2), 1: (3, 4)}
+
+
+def test_tracking_coco_json_validates_alignment(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    with pytest.raises(ValueError, match="identical lengths"):
+        node.forward(
+            **_build_inputs(
+                frame_idx=0,
+                mask_2d=torch.tensor([[0, 1], [0, 2]], dtype=torch.int32),
+                object_ids=[1, 2],
+                detection_scores=[0.9],
+            )
+        )
+
+
+def test_tracking_coco_json_writes_multi_category_tracks_and_header(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="object")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.5],
+            category_ids=[1],
+            category_semantics={1: "person"},
+        )
+    )
+    node.forward(
+        **_build_inputs(
+            frame_idx=1,
+            mask_2d=torch.tensor([[2, 2], [0, 1]], dtype=torch.int32),
+            object_ids=[1, 2],
+            detection_scores=[0.5, 0.25],
+            category_ids=[1, 2],
+            category_semantics={1: "person", 2: "car"},
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert parsed["categories"] == [{"id": 1, "name": "person"}, {"id": 2, "name": "car"}]
+    track_categories = {(ann["track_id"], ann["category_id"]) for ann in parsed["annotations"]}
+    assert track_categories == {(1, 1), (2, 2)}
+    # Track 1 appears on both frames -> one annotation per (track, frame).
+    assert sorted(ann["image_id"] for ann in parsed["annotations"] if ann["track_id"] == 1) == [
+        0,
+        1,
+    ]
+
+
+def test_tracking_coco_json_rejects_conflicting_track_category_ids(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="object")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.95],
+            category_ids=[1],
+            category_semantics={1: "person"},
+        )
+    )
+
+    with pytest.raises(ValueError, match="conflicting category IDs"):
+        node.forward(
+            **_build_inputs(
+                frame_idx=1,
+                mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+                object_ids=[1],
+                detection_scores=[0.94],
+                category_ids=[2],
+                category_semantics={1: "person", 2: "car"},
+            )
+        )
+
+
+def test_tracking_coco_json_ignores_background_id_zero(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[0, 1],
+            detection_scores=[0.75, 0.5],
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert len(parsed["annotations"]) == 1
+    ann = parsed["annotations"][0]
+    assert ann["track_id"] == 1
+    assert ann["score"] == 0.5
+
+
+def test_tracking_coco_json_atomic_write_is_parseable(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(
+        output_json_path=str(json_path),
+        default_category_name="person",
+        atomic_write=True,
+        flush_interval=1,
+    )
+
+    for frame_idx in range(12):
+        has_obj = frame_idx % 2 == 0
+        node.forward(
+            **_build_inputs(
+                frame_idx=frame_idx,
+                mask_2d=torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
+                if has_obj
+                else torch.zeros((2, 2), dtype=torch.int32),
+                object_ids=[1] if has_obj else [],
+                detection_scores=[0.8] if has_obj else [],
+            )
+        )
+        parsed = _read_json(json_path)
+        assert "images" in parsed
+        assert "annotations" in parsed
+
+    node.close()
+
+
+def test_tracking_coco_json_deferred_write_on_close(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.95],
+        )
+    )
+
+    assert not json_path.exists()
+
+    node.close()
+    assert json_path.exists()
+    parsed = _read_json(json_path)
+    assert [img["id"] for img in parsed["images"]] == [0]
+    assert len(parsed["annotations"]) == 1
+
+
+def test_tracking_coco_json_close_is_idempotent(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.95],
+        )
+    )
+
+    node.close()
+    node.close()
+    parsed = _read_json(json_path)
+    assert [img["id"] for img in parsed["images"]] == [0]
+
+
+def test_tracking_coco_json_flush_interval(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(
+        output_json_path=str(json_path), default_category_name="person", flush_interval=3
+    )
+
+    for i in range(2):
+        node.forward(
+            **_build_inputs(
+                frame_idx=i,
+                mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+                object_ids=[1],
+                detection_scores=[0.9],
+            )
+        )
+    assert not json_path.exists()
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=2,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.9],
+        )
+    )
+    assert json_path.exists()
+    parsed = _read_json(json_path)
+    assert [img["id"] for img in parsed["images"]] == [0, 1, 2]
+
+    node.close()
+
+
+def test_tracking_coco_json_validates_flush_interval(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="flush_interval"):
+        CocoTrackMaskWriter(
+            output_json_path=str(tmp_path / "test.json"),
+            flush_interval=-1,
+        )
+
+
+def test_tracking_coco_json_default_category_name_defaults_to_object(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path))
+
+    node.forward(
+        **_build_inputs(
+            frame_idx=0,
+            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
+            object_ids=[1],
+            detection_scores=[0.95],
+        )
+    )
+
+    node.close()
+    parsed = _read_json(json_path)
+    assert parsed["categories"] == [{"id": 1, "name": "object"}]
+
+
+def test_tracking_coco_json_rejects_invalid_dialect(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="dialect"):
+        CocoTrackMaskWriter(
+            output_json_path=str(tmp_path / "test.json"),
+            dialect="cocovid",
+        )
+
+
+def test_tracking_coco_json_no_frames_writes_no_file(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(output_json_path=str(json_path))
+    node.close()
+    assert not json_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Video dialect (opt-in legacy shape)
+# ---------------------------------------------------------------------------
+
+
+def test_tracking_coco_json_video_dialect_writes_track_shape(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking_results.json"
+    node = CocoTrackMaskWriter(
+        output_json_path=str(json_path),
+        dialect="video",
+        default_category_name="person",
+        flush_interval=1,
     )
 
     frames = (
@@ -84,274 +477,50 @@ def test_tracking_coco_json_writes_valid_json_after_each_frame(tmp_path: Path) -
         assert len(ann["areas"]) == 3
 
 
-def test_tracking_coco_json_replaces_existing_frame_idempotently(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=4,
-            mask_2d=torch.tensor([[1, 1], [0, 0]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.25],
-        )
-    )
-    node.forward(
-        **_build_inputs(
-            frame_idx=4,
-            mask_2d=torch.tensor([[1, 1], [0, 0]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.91],
-        )
-    )
-
-    node.close()
-    parsed = _read_json(json_path)
-    assert parsed["videos"][0]["frame_indices"] == [4]
-    assert len(parsed["annotations"]) == 1
-    assert parsed["annotations"][0]["detection_scores"] == pytest.approx([0.91])
-
-
-def test_tracking_coco_json_writes_empty_frame_entry(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=7,
-            mask_2d=torch.zeros((3, 4), dtype=torch.int32),
-            object_ids=[],
-            detection_scores=[],
-        )
-    )
-
-    node.close()
-    parsed = _read_json(json_path)
-    assert parsed["videos"][0]["frame_indices"] == [7]
-    assert parsed["videos"][0]["height"] == 3
-    assert parsed["videos"][0]["width"] == 4
-    assert parsed["annotations"] == []
-
-
-def test_tracking_coco_json_validates_alignment(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
-
-    with pytest.raises(ValueError, match="identical lengths"):
-        node.forward(
-            **_build_inputs(
-                frame_idx=0,
-                mask_2d=torch.tensor([[0, 1], [0, 2]], dtype=torch.int32),
-                object_ids=[1, 2],
-                detection_scores=[0.9],
-            )
-        )
-
-
-def test_tracking_coco_json_writes_multi_category_tracks_and_header(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="object")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=0,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.95],
-            category_ids=[1],
-            category_semantics={1: "person"},
-        )
-    )
-    node.forward(
-        **_build_inputs(
-            frame_idx=1,
-            mask_2d=torch.tensor([[2, 2], [0, 1]], dtype=torch.int32),
-            object_ids=[1, 2],
-            detection_scores=[0.93, 0.81],
-            category_ids=[1, 2],
-            category_semantics={1: "person", 2: "car"},
-        )
-    )
-
-    node.close()
-    parsed = _read_json(json_path)
-    assert parsed["categories"] == [{"id": 1, "name": "person"}, {"id": 2, "name": "car"}]
-    annotations_by_track = {ann["track_id"]: ann for ann in parsed["annotations"]}
-    assert annotations_by_track[1]["category_id"] == 1
-    assert annotations_by_track[2]["category_id"] == 2
-
-
-def test_tracking_coco_json_rejects_conflicting_track_category_ids(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="object")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=0,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.95],
-            category_ids=[1],
-            category_semantics={1: "person"},
-        )
-    )
-
-    with pytest.raises(ValueError, match="conflicting category IDs"):
-        node.forward(
-            **_build_inputs(
-                frame_idx=1,
-                mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-                object_ids=[1],
-                detection_scores=[0.94],
-                category_ids=[2],
-                category_semantics={1: "person", 2: "car"},
-            )
-        )
-
-
-def test_tracking_coco_json_ignores_background_id_zero(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=0,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[0, 1],
-            detection_scores=[0.99, 0.95],
-        )
-    )
-
-    node.close()
-    parsed = _read_json(json_path)
-    assert len(parsed["annotations"]) == 1
-    ann = parsed["annotations"][0]
-    assert ann["track_id"] == 1
-    assert ann["detection_scores"] == pytest.approx([0.95])
-
-
-def test_tracking_coco_json_atomic_write_is_parseable(tmp_path: Path) -> None:
+def test_tracking_coco_json_video_dialect_golden_payload(tmp_path: Path) -> None:
+    """Pin the exact legacy payload so the opt-in video dialect cannot drift."""
     json_path = tmp_path / "tracking_results.json"
     node = CocoTrackMaskWriter(
         output_json_path=str(json_path),
+        dialect="video",
         default_category_name="person",
-        atomic_write=True,
-        flush_interval=1,
     )
-
-    for frame_idx in range(12):
-        has_obj = frame_idx % 2 == 0
-        node.forward(
-            **_build_inputs(
-                frame_idx=frame_idx,
-                mask_2d=torch.tensor([[0, 1], [1, 0]], dtype=torch.int32)
-                if has_obj
-                else torch.zeros((2, 2), dtype=torch.int32),
-                object_ids=[1] if has_obj else [],
-                detection_scores=[0.8] if has_obj else [],
-            )
-        )
-        parsed = _read_json(json_path)
-        assert "videos" in parsed
-        assert "annotations" in parsed
-
-    node.close()
-
-
-def test_tracking_coco_json_deferred_write_on_close(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
 
     node.forward(
         **_build_inputs(
             frame_idx=0,
             mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
             object_ids=[1],
-            detection_scores=[0.95],
+            detection_scores=[0.5],
         )
     )
-
-    assert not json_path.exists()
-
-    node.close()
-    assert json_path.exists()
-    parsed = _read_json(json_path)
-    assert parsed["videos"][0]["frame_indices"] == [0]
-    assert len(parsed["annotations"]) == 1
-
-
-def test_tracking_coco_json_close_is_idempotent(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=0,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.95],
-        )
-    )
-
-    node.close()
-    node.close()
-    parsed = _read_json(json_path)
-    assert parsed["videos"][0]["frame_indices"] == [0]
-
-
-def test_tracking_coco_json_flush_interval(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(
-        output_json_path=str(json_path), default_category_name="person", flush_interval=3
-    )
-
-    for i in range(2):
-        node.forward(
-            **_build_inputs(
-                frame_idx=i,
-                mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-                object_ids=[1],
-                detection_scores=[0.9],
-            )
-        )
-    assert not json_path.exists()
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=2,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.9],
-        )
-    )
-    assert json_path.exists()
-    parsed = _read_json(json_path)
-    assert parsed["videos"][0]["frame_indices"] == [0, 1, 2]
-
     node.close()
 
-
-def test_tracking_coco_json_validates_flush_interval(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="flush_interval"):
-        CocoTrackMaskWriter(
-            output_json_path=str(tmp_path / "test.json"),
-            flush_interval=-1,
-        )
-
-
-def test_tracking_coco_json_default_category_name_defaults_to_object(tmp_path: Path) -> None:
-    json_path = tmp_path / "tracking_results.json"
-    node = CocoTrackMaskWriter(output_json_path=str(json_path))
-
-    node.forward(
-        **_build_inputs(
-            frame_idx=0,
-            mask_2d=torch.tensor([[0, 1], [0, 1]], dtype=torch.int32),
-            object_ids=[1],
-            detection_scores=[0.95],
-        )
-    )
-
-    node.close()
-    parsed = _read_json(json_path)
-    assert parsed["categories"] == [{"id": 1, "name": "object"}]
+    rle = coco_rle_encode(np.array([[0, 1], [0, 1]], dtype=np.uint8))
+    expected = {
+        "info": {"description": "Mask tracking results", "version": "1.0"},
+        "videos": [
+            {
+                "id": 1,
+                "name": "tracking_results",
+                "frame_indices": [0],
+                "start_frame": 0,
+                "length": 1,
+                "height": 2,
+                "width": 2,
+            }
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "track_id": 1,
+                "category_id": 1,
+                "segmentations": [rle],
+                "detection_scores": [0.5],
+                "bboxes": [coco_rle_to_bbox(rle)],
+                "areas": [2.0],
+            }
+        ],
+        "categories": [{"id": 1, "name": "person"}],
+    }
+    assert _read_json(json_path) == expected

--- a/tests/node/test_tracking_rle_roundtrip.py
+++ b/tests/node/test_tracking_rle_roundtrip.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import numpy as np
+import pytest
 import torch
 
 from cuvis_ai.node.json_file import CocoTrackMaskWriter, TrackingResultsReader
-from cuvis_ai_core.data.rle import coco_rle_decode
+from cuvis_ai_core.data.rle import coco_rle_decode, coco_rle_encode
 
 
 def _build_inputs(
@@ -25,6 +27,29 @@ def _build_inputs(
     }
 
 
+def _write_image_dialect(tmp_path: Path, annotations: list[dict], images: list[dict]) -> Path:
+    path = tmp_path / "image_dialect.json"
+    payload = {
+        "info": {},
+        "images": images,
+        "annotations": annotations,
+        "categories": [{"id": 1, "name": "object"}],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _rect_rle(height: int, width: int, r0: int, r1: int, c0: int, c1: int) -> dict:
+    mask = np.zeros((height, width), dtype=np.uint8)
+    mask[r0:r1, c0:c1] = 1
+    return coco_rle_encode(mask)
+
+
+# ---------------------------------------------------------------------------
+# Writer -> reader roundtrips
+# ---------------------------------------------------------------------------
+
+
 def test_roundtrip_single_object_mask(tmp_path: Path) -> None:
     json_path = tmp_path / "tracking.json"
     writer = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
@@ -34,12 +59,14 @@ def test_roundtrip_single_object_mask(tmp_path: Path) -> None:
     writer.close()
 
     reader = TrackingResultsReader(json_path=str(json_path))
-    assert reader.format == "video_coco"
+    assert reader.format == "coco_bbox"
     out = reader.forward()
 
     assert out["object_ids"][0].tolist() == [1]
     assert out["mask"].shape == (1, 2, 3)
     assert torch.equal(out["mask"][0], mask_2d)
+    assert out["track_ids"][0].tolist() == [1]
+    assert out["bboxes"].shape == (1, 1, 4)
 
 
 def test_roundtrip_multi_object_mask(tmp_path: Path) -> None:
@@ -60,6 +87,24 @@ def test_roundtrip_multi_object_mask(tmp_path: Path) -> None:
     assert torch.equal(out["mask"][0], mask_2d)
 
 
+def test_roundtrip_video_dialect(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking.json"
+    writer = CocoTrackMaskWriter(
+        output_json_path=str(json_path), dialect="video", default_category_name="person"
+    )
+
+    mask_2d = torch.tensor([[0, 1, 1], [0, 1, 0]], dtype=torch.int32)
+    writer.forward(**_build_inputs(0, mask_2d, [1], [0.9]))
+    writer.close()
+
+    reader = TrackingResultsReader(json_path=str(json_path))
+    assert reader.format == "video_coco"
+    out = reader.forward()
+
+    assert out["object_ids"][0].tolist() == [1]
+    assert torch.equal(out["mask"][0], mask_2d)
+
+
 def test_rle_segmentation_valid_in_json(tmp_path: Path) -> None:
     json_path = tmp_path / "tracking.json"
     writer = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
@@ -72,8 +117,7 @@ def test_rle_segmentation_valid_in_json(tmp_path: Path) -> None:
         data = json.load(f)
 
     ann = data["annotations"][0]
-    rle = ann["segmentations"][0]
-    decoded = coco_rle_decode(rle)
+    decoded = coco_rle_decode(ann["segmentation"])
 
     assert decoded.shape == (2, 3)
     expected = (mask_2d == 1).numpy().astype("uint8")
@@ -93,15 +137,15 @@ def test_rle_non_square_mask_in_json(tmp_path: Path) -> None:
     with json_path.open(encoding="utf-8") as f:
         data = json.load(f)
 
-    rle = data["annotations"][0]["segmentations"][0]
-    decoded = coco_rle_decode(rle)
+    decoded = coco_rle_decode(data["annotations"][0]["segmentation"])
 
     assert decoded.shape == (3, 7)
     assert (decoded[0, :] == 1).all()
     assert (decoded[1:, :] == 0).all()
 
 
-def test_roundtrip_empty_frame(tmp_path: Path) -> None:
+def test_roundtrip_empty_frame_in_mask_session(tmp_path: Path) -> None:
+    """A frame without objects reads back as a zero label map at the frame size."""
     json_path = tmp_path / "tracking.json"
     writer = CocoTrackMaskWriter(
         output_json_path=str(json_path),
@@ -110,12 +154,161 @@ def test_roundtrip_empty_frame(tmp_path: Path) -> None:
     )
 
     mask_2d = torch.zeros((4, 4), dtype=torch.int32)
-    writer.forward(**_build_inputs(0, mask_2d, [], []))
+    mask_2d[0, 0] = 1
+    writer.forward(**_build_inputs(0, mask_2d, [1], [0.9]))
+    writer.forward(**_build_inputs(1, torch.zeros((4, 4), dtype=torch.int32), [], []))
+    writer.close()
+
+    reader = TrackingResultsReader(json_path=str(json_path))
+    out0 = reader.forward()
+    out1 = reader.forward()
+
+    assert torch.equal(out0["mask"][0], mask_2d)
+    assert out1["object_ids"].shape == (1, 0)
+    assert out1["mask"].shape == (1, 4, 4)
+    assert torch.count_nonzero(out1["mask"]).item() == 0
+
+
+def test_all_empty_session_keeps_legacy_empty_mask(tmp_path: Path) -> None:
+    """A file with no segmentations at all keeps the legacy empty mask shape."""
+    json_path = tmp_path / "tracking.json"
+    writer = CocoTrackMaskWriter(
+        output_json_path=str(json_path),
+        default_category_name="person",
+        write_empty_frames=True,
+    )
+    writer.forward(**_build_inputs(0, torch.zeros((4, 4), dtype=torch.int32), [], []))
     writer.close()
 
     reader = TrackingResultsReader(json_path=str(json_path))
     out = reader.forward()
 
+    assert out["mask"].shape == (1, 0, 0)
     assert out["object_ids"].shape == (1, 0)
-    assert out["mask"].shape == (1, 4, 4)
-    assert torch.count_nonzero(out["mask"]).item() == 0
+
+
+def test_required_format_matches_image_dialect_output(tmp_path: Path) -> None:
+    json_path = tmp_path / "tracking.json"
+    writer = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+    writer.forward(
+        **_build_inputs(0, torch.tensor([[0, 1], [0, 1]], dtype=torch.int32), [1], [0.9])
+    )
+    writer.close()
+
+    reader = TrackingResultsReader(json_path=str(json_path), required_format="coco_bbox")
+    assert reader.forward()["object_ids"][0].tolist() == [1]
+
+    mismatched = TrackingResultsReader(json_path=str(json_path), required_format="video_coco")
+    with pytest.raises(ValueError, match="required_format"):
+        mismatched.forward()
+
+
+# ---------------------------------------------------------------------------
+# Image-dialect reader specifics (hand-written files)
+# ---------------------------------------------------------------------------
+
+
+def test_reader_derives_bbox_from_bboxless_segmentation(tmp_path: Path) -> None:
+    rle = _rect_rle(4, 6, 1, 3, 2, 5)
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[{"id": 1, "image_id": 0, "category_id": 1, "segmentation": rle}],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 4, "width": 6}],
+    )
+
+    out = TrackingResultsReader(json_path=str(path)).forward()
+
+    assert out["bboxes"][0].tolist() == [[2.0, 1.0, 5.0, 3.0]]  # xyxy from RLE
+    assert (out["mask"][0][1:3, 2:5] == 1).all()  # no track_id -> annotation id
+    assert out["object_ids"][0].tolist() == [1]
+
+
+def test_reader_overlap_higher_annotation_id_wins(tmp_path: Path) -> None:
+    base = _rect_rle(4, 4, 0, 3, 0, 3)
+    overlap = _rect_rle(4, 4, 1, 4, 1, 4)
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[
+            {"id": 2, "image_id": 0, "category_id": 1, "segmentation": overlap, "track_id": 3},
+            {"id": 1, "image_id": 0, "category_id": 1, "segmentation": base, "track_id": 5},
+        ],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 4, "width": 4}],
+    )
+
+    out = TrackingResultsReader(json_path=str(path)).forward()
+
+    # Annotation id 2 (track 3) paints last: the overlapping pixel belongs to track 3.
+    assert int(out["mask"][0][1, 1]) == 3
+    assert int(out["mask"][0][0, 0]) == 5
+    assert out["object_ids"][0].tolist() == [3, 5]
+
+
+def test_reader_rejects_rle_size_mismatch(tmp_path: Path) -> None:
+    rle = _rect_rle(3, 3, 0, 2, 0, 2)
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[{"id": 1, "image_id": 0, "category_id": 1, "segmentation": rle}],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 5, "width": 5}],
+    )
+
+    with pytest.raises(ValueError, match="disagrees with the image record"):
+        TrackingResultsReader(json_path=str(path)).forward()
+
+
+def test_reader_mixed_bbox_and_mask_annotations(tmp_path: Path) -> None:
+    rle = _rect_rle(4, 4, 0, 2, 0, 2)
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[
+            {"id": 1, "image_id": 0, "category_id": 1, "segmentation": rle, "track_id": 7},
+            {
+                "id": 2,
+                "image_id": 0,
+                "category_id": 1,
+                "bbox": [1.0, 1.0, 2.0, 2.0],
+                "track_id": 8,
+            },
+        ],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 4, "width": 4}],
+    )
+
+    out = TrackingResultsReader(json_path=str(path)).forward()
+
+    assert out["bboxes"].shape == (1, 2, 4)
+    assert out["track_ids"][0].tolist() == [7, 8]
+    # Only the segmentation-bearing annotation lands in the label map.
+    assert out["object_ids"][0].tolist() == [7]
+    assert int((out["mask"][0] == 7).sum()) == 4
+
+
+def test_reader_rejects_annotation_without_bbox_or_segmentation(tmp_path: Path) -> None:
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[{"id": 1, "image_id": 0, "category_id": 1}],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 4, "width": 4}],
+    )
+
+    with pytest.raises(ValueError, match="neither a bbox nor an RLE segmentation"):
+        TrackingResultsReader(json_path=str(path)).forward()
+
+
+def test_reader_pure_bbox_file_keeps_legacy_empty_mask(tmp_path: Path) -> None:
+    path = _write_image_dialect(
+        tmp_path,
+        annotations=[
+            {
+                "id": 1,
+                "image_id": 0,
+                "category_id": 1,
+                "bbox": [1.0, 1.0, 2.0, 2.0],
+                "track_id": 4,
+            }
+        ],
+        images=[{"id": 0, "file_name": "frame_000000", "height": 4, "width": 4}],
+    )
+
+    out = TrackingResultsReader(json_path=str(path)).forward()
+
+    assert out["mask"].shape == (1, 0, 0)
+    assert out["object_ids"].shape == (1, 0)
+    assert out["track_ids"][0].tolist() == [4]

--- a/tests/node/test_tracking_writer_consumers.py
+++ b/tests/node/test_tracking_writer_consumers.py
@@ -1,0 +1,86 @@
+"""Integration tests: actual CocoTrackMaskWriter output feeding downstream consumers.
+
+The consumer tests elsewhere construct image-dialect JSON by hand, so they alone cannot
+prove the writer's default output is readable. These feed real writer files into
+``MaskPrompt``, the occlusion nodes, and ``append_tracking_metrics``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from cuvis_ai.node.json_file import CocoTrackMaskWriter
+from cuvis_ai.node.occlusion import SolidOcclusionNode
+from cuvis_ai.node.prompts import MaskPrompt
+from cuvis_ai.utils.cli_helpers import append_tracking_metrics
+
+
+@pytest.fixture
+def writer_output(tmp_path: Path) -> tuple[Path, torch.Tensor]:
+    """One frame with two tracked rectangles, written by the real writer (image dialect)."""
+    json_path = tmp_path / "tracking.json"
+    writer = CocoTrackMaskWriter(output_json_path=str(json_path), default_category_name="person")
+
+    label_map = torch.zeros((8, 10), dtype=torch.int32)
+    label_map[2:5, 3:7] = 1
+    label_map[5:8, 0:3] = 2
+    writer.forward(
+        frame_id=torch.tensor([0], dtype=torch.int64),
+        mask=label_map.unsqueeze(0),
+        object_ids=torch.tensor([[1, 2]], dtype=torch.int64),
+        detection_scores=torch.tensor([[0.5, 0.25]], dtype=torch.float32),
+    )
+    writer.close()
+    return json_path, label_map
+
+
+def test_mask_prompt_consumes_writer_output(
+    writer_output: tuple[Path, torch.Tensor],
+) -> None:
+    json_path, label_map = writer_output
+
+    node = MaskPrompt(json_path=str(json_path), prompt_specs=["9:1@0"])
+    out = node.forward(frame_id=torch.tensor([0], dtype=torch.int64))
+
+    assert out["mask"].shape == (1, 8, 10)
+    expected = (label_map == 1).to(torch.int32) * 9
+    assert torch.equal(out["mask"][0], expected)
+
+
+def test_occlusion_node_consumes_writer_output(
+    writer_output: tuple[Path, torch.Tensor],
+) -> None:
+    json_path, label_map = writer_output
+
+    node = SolidOcclusionNode(
+        tracking_json_path=str(json_path),
+        track_ids=[1],
+        occlusion_start_frame=0,
+        occlusion_end_frame=0,
+        fill_color=(0.0, 1.0, 0.0),
+        occlusion_shape="mask",
+    )
+    rgb = torch.full((1, 8, 10, 3), 0.2, dtype=torch.float32)
+    out = node.forward(rgb_image=rgb, frame_id=torch.tensor([0], dtype=torch.int64))["rgb_image"]
+
+    track_mask = label_map == 1
+    assert out[0][track_mask, 1].min().item() == pytest.approx(1.0)
+    assert torch.equal(out[0][~track_mask, :], rgb[0][~track_mask, :])
+
+
+def test_append_tracking_metrics_consumes_writer_output(
+    writer_output: tuple[Path, torch.Tensor], tmp_path: Path
+) -> None:
+    json_path, _ = writer_output
+    info_path = tmp_path / "experiment_info.txt"
+    info_path.write_text("Experiment: test\n", encoding="utf-8")
+
+    append_tracking_metrics(info_path, json_path)
+
+    content = info_path.read_text(encoding="utf-8")
+    assert "frames: 1" in content
+    assert "unique_track_ids: 2" in content
+    assert "zero_track_frames: 0" in content


### PR DESCRIPTION
## Problem

`CocoTrackMaskWriter` emitted a YouTube-VIS-shaped track dialect: top-level `videos[]`, one annotation per track with per-frame parallel arrays, and no `image_id` anywhere. pycocotools cannot index that shape, so the writer's own ecosystem could not consume its output: training via `CocoLabeler` failed with a bare `KeyError: 'image_id'`, cuvis-ai-trackeval could not evaluate mask-tracking runs (it reads only `images[]` + `image_id`), and the occlusion nodes and `append_tracking_metrics` KeyError on it too. Meanwhile the sibling `CocoTrackBBoxWriter` already wrote image-keyed COCO — the two writers disagreed on dialect for no documented reason.

## Changes

- **`CocoTrackMaskWriter` defaults to standard image-keyed COCO** (`dialect: image`): per-frame `images[]` records (`frame_%06d`, per-frame height/width) plus one annotation per (track, frame) with RLE `segmentation`, `bbox`, `area`, `iscrowd: 1`, and additive `score`/`track_id` — mirroring `CocoTrackBBoxWriter`. The legacy shape stays available as an explicit opt-in (`dialect: video`, pinned byte-for-byte by a golden test). This is a **breaking output-schema change** for the 10 pipeline configs that wire the writer (they only set `output_json_path`, so no config edits) — CHANGELOG carries the migration note.
- **`TrackingResultsReader`'s image-dialect path now reconstructs masks**: per-annotation RLE `segmentation` dicts become the `mask` label map + `object_ids` (pixel = `track_id`, annotation id when track_id is missing/negative; overlaps painted in ascending annotation-id order so the winner is deterministic; RLE dimensions validated against the image record), and `bbox` is derived from the RLE for bbox-less annotations — which also makes CuvisNEXT image-dialect mask exports readable in pipelines. Pure bbox files behave exactly as before.
- Builtin manifest `doc_summary` refreshed; **dataloader pin bumped v0.5.1 -> v0.6.0** (cubert-hyperspectral/cuvis-ai-dataloader#23: `CocoLabeler` reads both dialects + standard RLE-object segmentations), completing the end-to-end training fix for tracked sessions.

Legacy track-dialect files on disk keep working everywhere: `TrackingResultsReader` and the prompt nodes read both dialects, and dataloader 0.6.0 converts them in memory.

## Tests

- Writer: image-default assertions (payload key sets, per-frame dimensions, `frame_%06d`, replacement idempotence, empty frames, flush/close lifecycle), video-dialect track-shape assertions plus a golden payload pin, invalid-dialect rejection, no-frames-no-file.
- Reader: dual-dialect roundtrips, overlap policy, bbox-less segmentation (bbox derived from RLE), RLE-size mismatch rejection, mixed bbox/mask annotations, `required_format` on both shapes, legacy empty-mask shape for pure bbox files.
- Integration: real writer output fed into `MaskPrompt`, `SolidOcclusionNode`, and `append_tracking_metrics` (the existing consumer tests all hand-build their JSON, so they alone never proved the writer's output is readable).
- Full suite: 1301 passed, 12 skipped.

## Merge order

Requires the cuvis-ai-dataloader `v0.6.0` tag to exist (manifest pin) — merge cubert-hyperspectral/cuvis-ai-dataloader#23 and tag first.
