### PR TITLE
Bump cuvis_ai_builtin manifest pin to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Bumped the `cuvis_ai_builtin` manifest pin v0.12.1 -> v0.13.0 so composed child environments install the released cuvis-ai matching the host.
+
 ## 0.13.0 - 2026-08-24
 
 - Security: bumped hydra-core 1.3.2 -> 1.3.5 (floor >=1.3.5, lock-aligned; CVE-2026-68508 fixed in 1.3.4, arbitrary code

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -9,7 +9,7 @@
 name: cuvis_ai_builtin
 package_name: cuvis-ai
 repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
-tag: "v0.12.1"
+tag: "v0.13.0"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform


### PR DESCRIPTION
Post-release pin bump per convention: composed child environments install the released cuvis-ai matching the host. Follows the 0.13.0 release.