### PR TITLE
feat(plugins): wafer_thickness v0.3.0 manifest and SiO2 thickness presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added the `wafer_thickness` plugin manifest (pinned `v0.3.0`, the release that renames the
+  `WaferThickness` uncertainty output from `order_disagreement` to `uncertainty`) and the four
+  wafer SiO2 thickness presets under `configs/pipeline/wafer_thickness/` (1000 nm and 500 nm
+  regimes, each as a base pipeline and a `_cuvisnext_cube` variant).
 - Bumped the `cuvis_ai_builtin` manifest pin v0.12.1 -> v0.13.0 so composed child environments install the released cuvis-ai matching the host.
 
 ## 0.13.0 - 2026-08-24

--- a/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline.yaml
+++ b/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline.yaml
@@ -1,0 +1,62 @@
+metadata:
+  name: WaferThicknessMapping
+  description: Per-pixel SiO2 film thickness map from a cu3s reflectance capture
+    (spectral-contrast wafer segmentation -> interference-order thickness).
+  created: ''
+  tags:
+  - wafer
+  - thin-film
+  - thickness
+  author: cuvis.ai
+plugins:
+- wafer_thickness
+- cuvis_ai_builtin
+nodes:
+- name: CU3SDataNode
+  class_name: cuvis_ai.node.data.CU3SDataNode
+  hparams: {}
+- name: WaferSegmentation
+  class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation
+  hparams:
+    wl_min: 450.0
+    wl_max: 880.0
+    open_px: 3
+    close_px: 7
+    erode_px: 10
+    min_area_frac: 0.03
+    backend: torch
+- name: WaferThickness
+  class_name: cuvis_ai_wafer_thickness.node.wafer_thickness.WaferThickness
+  hparams:
+    # nominal 1000 nm regime; for 500 nm use [[3, 460, 520], [2, 650, 775]]
+    orders:
+    - [6, 460, 515]
+    - [5, 550, 620]
+    - [4, 690, 785]
+    refractive_model: sellmeier
+    n_constant: 1.46
+    theta_air_deg: 5.0
+    sg_window: 7
+    sg_polyorder: 2
+    median_size: 5
+    backend: torch
+- name: ThicknessWriter
+  class_name: cuvis_ai.node.numpy_file.NumpyFeatureWriterNode
+  hparams:
+    output_dir: outputs/wafer_thickness
+    prefix: thickness_nm
+connections:
+- source: CU3SDataNode.outputs.cube
+  target: WaferSegmentation.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferSegmentation.inputs.wavelengths
+- source: CU3SDataNode.outputs.cube
+  target: WaferThickness.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferThickness.inputs.wavelengths
+- source: WaferSegmentation.outputs.mask
+  target: WaferThickness.inputs.mask
+- source: WaferThickness.outputs.thickness
+  target: ThicknessWriter.inputs.features
+- source: CU3SDataNode.outputs.mesu_index
+  target: ThicknessWriter.inputs.frame_id

--- a/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_500nm.yaml
+++ b/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_500nm.yaml
@@ -1,0 +1,61 @@
+metadata:
+  name: WaferThicknessMapping500nm
+  description: Per-pixel SiO2 film thickness map from a cu3s reflectance capture of a
+    nominal 500 nm wafer (spectral-contrast segmentation -> interference-order thickness).
+  created: ''
+  tags:
+  - wafer
+  - thin-film
+  - thickness
+  author: cuvis.ai
+plugins:
+- wafer_thickness
+- cuvis_ai_builtin
+nodes:
+- name: CU3SDataNode
+  class_name: cuvis_ai.node.data.CU3SDataNode
+  hparams: {}
+- name: WaferSegmentation
+  class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation
+  hparams:
+    wl_min: 450.0
+    wl_max: 880.0
+    open_px: 3
+    close_px: 7
+    erode_px: 10
+    min_area_frac: 0.03
+    backend: torch
+- name: WaferThickness
+  class_name: cuvis_ai_wafer_thickness.node.wafer_thickness.WaferThickness
+  hparams:
+    # nominal 500 nm regime: two interference orders inside 430-910 nm
+    orders:
+    - [3, 460, 520]
+    - [2, 650, 775]
+    refractive_model: sellmeier
+    n_constant: 1.46
+    theta_air_deg: 5.0
+    sg_window: 7
+    sg_polyorder: 2
+    median_size: 5
+    backend: torch
+- name: ThicknessWriter
+  class_name: cuvis_ai.node.numpy_file.NumpyFeatureWriterNode
+  hparams:
+    output_dir: outputs/wafer_thickness_500nm
+    prefix: thickness_nm
+connections:
+- source: CU3SDataNode.outputs.cube
+  target: WaferSegmentation.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferSegmentation.inputs.wavelengths
+- source: CU3SDataNode.outputs.cube
+  target: WaferThickness.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferThickness.inputs.wavelengths
+- source: WaferSegmentation.outputs.mask
+  target: WaferThickness.inputs.mask
+- source: WaferThickness.outputs.thickness
+  target: ThicknessWriter.inputs.features
+- source: CU3SDataNode.outputs.mesu_index
+  target: ThicknessWriter.inputs.frame_id

--- a/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_500nm_cuvisnext_cube.yaml
+++ b/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_500nm_cuvisnext_cube.yaml
@@ -1,0 +1,63 @@
+metadata:
+  name: WaferThicknessMapping500nmCuvisNextCube
+  description: CuvisNEXT cube-mode variant (500 nm regime) - upload via the CuvisNEXT
+    pipeline builder; CuvisNEXT injects the hyperspectral cube into CU3SDataNode at
+    runtime. Thickness pixel map is emitted on WaferThickness.outputs.thickness.
+  created: ''
+  tags:
+  - wafer
+  - thin-film
+  - thickness
+  - cuvisnext
+  author: cuvis.ai
+plugins:
+- wafer_thickness
+- cuvis_ai_builtin
+nodes:
+- name: CU3SDataNode
+  class_name: cuvis_ai.node.data.CU3SDataNode
+  hparams: {}
+- name: WaferSegmentation
+  class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation
+  hparams:
+    wl_min: 450.0
+    wl_max: 880.0
+    open_px: 3
+    close_px: 7
+    erode_px: 10
+    min_area_frac: 0.03
+    backend: torch
+- name: WaferThickness
+  class_name: cuvis_ai_wafer_thickness.node.wafer_thickness.WaferThickness
+  hparams:
+    # nominal 500 nm regime: two interference orders inside 430-910 nm
+    orders:
+    - [3, 460, 520]
+    - [2, 650, 775]
+    refractive_model: sellmeier
+    n_constant: 1.46
+    theta_air_deg: 5.0
+    sg_window: 7
+    sg_polyorder: 2
+    median_size: 5
+    backend: torch
+- name: ThicknessWriter
+  class_name: cuvis_ai.node.numpy_file.NumpyFeatureWriterNode
+  hparams:
+    output_dir: outputs/wafer_thickness_500nm
+    prefix: thickness_nm
+connections:
+- source: CU3SDataNode.outputs.cube
+  target: WaferSegmentation.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferSegmentation.inputs.wavelengths
+- source: CU3SDataNode.outputs.cube
+  target: WaferThickness.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferThickness.inputs.wavelengths
+- source: WaferSegmentation.outputs.mask
+  target: WaferThickness.inputs.mask
+- source: WaferThickness.outputs.thickness
+  target: ThicknessWriter.inputs.features
+- source: CU3SDataNode.outputs.mesu_index
+  target: ThicknessWriter.inputs.frame_id

--- a/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_cuvisnext_cube.yaml
+++ b/cuvis_ai/configs/pipeline/wafer_thickness/wafer_thickness_pipeline_cuvisnext_cube.yaml
@@ -1,0 +1,64 @@
+metadata:
+  name: WaferThicknessMappingCuvisNextCube
+  description: CuvisNEXT cube-mode variant (1000 nm regime) - upload via the CuvisNEXT
+    pipeline builder; CuvisNEXT injects the hyperspectral cube into CU3SDataNode at
+    runtime. Thickness pixel map is emitted on WaferThickness.outputs.thickness.
+  created: ''
+  tags:
+  - wafer
+  - thin-film
+  - thickness
+  - cuvisnext
+  author: cuvis.ai
+plugins:
+- wafer_thickness
+- cuvis_ai_builtin
+nodes:
+- name: CU3SDataNode
+  class_name: cuvis_ai.node.data.CU3SDataNode
+  hparams: {}
+- name: WaferSegmentation
+  class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation
+  hparams:
+    wl_min: 450.0
+    wl_max: 880.0
+    open_px: 3
+    close_px: 7
+    erode_px: 10
+    min_area_frac: 0.03
+    backend: torch
+- name: WaferThickness
+  class_name: cuvis_ai_wafer_thickness.node.wafer_thickness.WaferThickness
+  hparams:
+    # nominal 1000 nm regime; for 500 nm use [[3, 460, 520], [2, 650, 775]]
+    orders:
+    - [6, 460, 515]
+    - [5, 550, 620]
+    - [4, 690, 785]
+    refractive_model: sellmeier
+    n_constant: 1.46
+    theta_air_deg: 5.0
+    sg_window: 7
+    sg_polyorder: 2
+    median_size: 5
+    backend: torch
+- name: ThicknessWriter
+  class_name: cuvis_ai.node.numpy_file.NumpyFeatureWriterNode
+  hparams:
+    output_dir: outputs/wafer_thickness
+    prefix: thickness_nm
+connections:
+- source: CU3SDataNode.outputs.cube
+  target: WaferSegmentation.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferSegmentation.inputs.wavelengths
+- source: CU3SDataNode.outputs.cube
+  target: WaferThickness.inputs.cube
+- source: CU3SDataNode.outputs.wavelengths
+  target: WaferThickness.inputs.wavelengths
+- source: WaferSegmentation.outputs.mask
+  target: WaferThickness.inputs.mask
+- source: WaferThickness.outputs.thickness
+  target: ThicknessWriter.inputs.features
+- source: CU3SDataNode.outputs.mesu_index
+  target: ThicknessWriter.inputs.frame_id

--- a/cuvis_ai/configs/plugins/wafer_thickness.yaml
+++ b/cuvis_ai/configs/plugins/wafer_thickness.yaml
@@ -1,0 +1,65 @@
+# Wafer Thickness Plugin Manifest
+#
+# To use it, declare `plugins: [wafer_thickness]` in the pipeline yaml and point
+# the loader at the catalog directory that holds this manifest:
+#   uv run restore-pipeline --pipeline-path <pipeline>.yaml --plugins-dir cuvis_ai/configs/plugins
+
+name: wafer_thickness
+repo: "https://github.com/cubert-hyperspectral/cuvis-ai-wafer-thickness.git"
+tag: "v0.3.0"
+package_name: "cuvis-ai-wafer-thickness"
+capabilities:
+- class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation
+  category: transform
+  tags: [hyperspectral, mask, numpy, segmentation, torch]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#6FAE5C\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M52 26a20 20 0 0 0-36 0\"/>\n  <path d=\"M52 16v10h-10\"/>\n  <path d=\"M12 38a20 20 0 0 0 36 0\"/>\n  <path d=\"M12 48v-10h10\"/>\n</svg>\n"
+  input_specs:
+    cube:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Hyperspectral reflectance cube [B, H, W, C].
+    wavelengths:
+      dtype: int32
+      shape: [-1]
+      optional: false
+      description: Wavelengths [C] in nm.
+  output_specs:
+    mask:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Wafer mask [B, H, W]; non-zero = wafer.
+  doc_summary: Segment a wafer from a flat background by spectral contrast.
+- class_name: cuvis_ai_wafer_thickness.node.wafer_thickness.WaferThickness
+  category: transform
+  tags: [hyperspectral, numpy, regression, torch]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#6FAE5C\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M52 26a20 20 0 0 0-36 0\"/>\n  <path d=\"M52 16v10h-10\"/>\n  <path d=\"M12 38a20 20 0 0 0 36 0\"/>\n  <path d=\"M12 48v-10h10\"/>\n</svg>\n"
+  input_specs:
+    cube:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Hyperspectral reflectance cube [B, H, W, C].
+    wavelengths:
+      dtype: int32
+      shape: [-1]
+      optional: false
+      description: Wavelengths [C] in nm.
+    mask:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: true
+      description: 'Wafer mask [B, H, W]; non-zero = analyse. Optional: omitted = all pixels.'
+  output_specs:
+    thickness:
+      dtype: float32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Per-pixel film thickness [B, H, W] in nm; NaN outside mask.
+    uncertainty:
+      dtype: float32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Std of per-order thickness estimates [B, H, W] in nm (lower is better; 0 for a single order); NaN outside mask.
+  doc_summary: Per-pixel film thickness [nm] from interference-order peak positions.


### PR DESCRIPTION
Ships the `wafer_thickness` plugin manifest, frozen at `v0.3.0` - the release that renames the uncertainty output from `order_disagreement` to `uncertainty` - and the four wafer SiO2 thickness presets under `configs/pipeline/wafer_thickness/`: 1000 nm and 500 nm regimes, each as a base pipeline and a `_cuvisnext_cube` variant taking the cube CuvisNEXT injects at runtime.

The manifest is the plugin repo's emitted `plugins.yaml` (port specs generated by `emit_metadata`, not hand-edited) with the local `path:` replaced by the frozen `repo:` + `tag:` pin; the presets are byte-identical to the plugin repo's. Pipelines reference the plugin by bare name (`plugins: [wafer_thickness, cuvis_ai_builtin]`).