### PR TITLE
feat(node): implement max_initialization_frames in MinMaxNormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.2 - 2026-08-26
 
 - `MinMaxNormalizer` now implements `max_initialization_frames: int | None = None`: `statistical_initialization` consumes at most that many frames (slicing the final batch and stopping the stream early) instead of always scanning the whole training stream. The kwarg was previously swallowed into hparams as a silent no-op, so configs that already set it (the shipped `dinomaly_rgb` / `dinomaly_cir` presets with `max_initialization_frames: 20`, and the dinomaly plugin's trainrun configs and notebooks) now take effect.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `MinMaxNormalizer` now implements `max_initialization_frames: int | None = None`: `statistical_initialization` consumes at most that many frames (slicing the final batch and stopping the stream early) instead of always scanning the whole training stream. The kwarg was previously swallowed into hparams as a silent no-op, so configs that already set it (the shipped `dinomaly_rgb` / `dinomaly_cir` presets with `max_initialization_frames: 20`, and the dinomaly plugin's trainrun configs and notebooks) now take effect.
+
 - Bumped the `dinomaly` manifest pin v0.6.1 -> v0.6.2: `AnomalyAUROCMetrics` now opts into the trainer's pooled epoch-end reduction (`POOLED_METRIC_NAMES` / `pooled_metrics()`), so the reported val/test AUROC is one exact pooled `compute()` per epoch instead of the batch-size-biased mean of per-batch running values.
 
 - Added `rtsam2_point_expansion_postprocess_view.yaml`: the RTSAM2 point-expansion view

--- a/cuvis_ai/node/normalization.py
+++ b/cuvis_ai/node/normalization.py
@@ -164,6 +164,10 @@ class MinMaxNormalizer(_ScoreNormalizerBase):
     use_running_stats : bool, optional
         If True, use global min/max from statistical_initialization(). If False, compute
         min/max per batch during forward pass (default: True)
+    max_initialization_frames : int or None, optional
+        Cap on the number of frames (batch elements) consumed by
+        statistical_initialization(): the final batch is sliced to the cap and the input
+        stream is not iterated further. None uses the entire training stream (default: None)
     **kwargs : dict
         Additional arguments passed to Node base class
 
@@ -212,10 +216,24 @@ class MinMaxNormalizer(_ScoreNormalizerBase):
 
     TRAINABLE_BUFFERS = ("running_min", "running_max")
 
-    def __init__(self, eps: float = 1e-6, use_running_stats: bool = True, **kwargs) -> None:
+    def __init__(
+        self,
+        eps: float = 1e-6,
+        use_running_stats: bool = True,
+        max_initialization_frames: int | None = None,
+        **kwargs,
+    ) -> None:
+        if max_initialization_frames is not None and max_initialization_frames <= 0:
+            raise ValueError("max_initialization_frames must be None or a positive integer.")
         self.eps = float(eps)
         self.use_running_stats = use_running_stats
-        super().__init__(eps=eps, use_running_stats=use_running_stats, **kwargs)
+        self.max_initialization_frames = max_initialization_frames
+        super().__init__(
+            eps=eps,
+            use_running_stats=use_running_stats,
+            max_initialization_frames=max_initialization_frames,
+            **kwargs,
+        )
 
         # Running statistics for global normalization
         self.register_buffer("running_min", torch.tensor(float("nan")))
@@ -226,6 +244,9 @@ class MinMaxNormalizer(_ScoreNormalizerBase):
 
     def statistical_initialization(self, input_stream) -> None:
         """Compute global min/max from data iterator.
+
+        Consumes at most ``max_initialization_frames`` frames when the cap is set: the
+        final batch is sliced to the cap and the stream is not iterated further.
 
         Parameters
         ----------
@@ -240,17 +261,24 @@ class MinMaxNormalizer(_ScoreNormalizerBase):
 
         all_mins = []
         all_maxs = []
+        cap = self.max_initialization_frames
+        frames_seen = 0
 
         for batch_data in input_stream:
             # Extract data from port-based dict
             x = batch_data.get("data")
             if x is not None:
+                if cap is not None:
+                    x = x[: cap - frames_seen]
+                frames_seen += x.shape[0]
                 # Flatten spatial dimensions
                 flat = x.reshape(x.shape[0], -1)
                 batch_min = flat.min()
                 batch_max = flat.max()
                 all_mins.append(batch_min)
                 all_maxs.append(batch_max)
+                if cap is not None and frames_seen >= cap:
+                    break
 
         if not all_mins:
             raise RuntimeError(

--- a/tests/training/test_statistical_initialization.py
+++ b/tests/training/test_statistical_initialization.py
@@ -151,6 +151,59 @@ def test_critical_statistical_nodes_reject_empty_initialization(factory):
     assert node._statistically_initialized is False
 
 
+def test_minmax_cap_limits_initialization_frames():
+    """max_initialization_frames slices the final batch and stops the stream early.
+
+    Frames past the cap carry extreme values; the running min/max must not see them.
+    """
+    node = MinMaxNormalizer(use_running_stats=True, max_initialization_frames=3)
+
+    consumed = []
+
+    def data_iterator():
+        # Batch 1: 2 frames in [0, 1). Batch 2: frame 1 all 2.5, frame 2 all 1000.0
+        # (past the cap, must be sliced off). Batch 3 must never be pulled at all.
+        consumed.append(1)
+        yield {"data": torch.rand(2, 4, 4, 1)}
+        consumed.append(2)
+        yield {"data": torch.stack([torch.full((4, 4, 1), 2.5), torch.full((4, 4, 1), 1000.0)])}
+        consumed.append(3)
+        yield {"data": torch.full((2, 4, 4, 1), -1000.0)}
+
+    node.statistical_initialization(data_iterator())
+
+    assert consumed == [1, 2]
+    assert node._statistically_initialized is True
+    assert float(node.running_max) == pytest.approx(2.5)
+    assert 0.0 <= float(node.running_min) < 1.0
+
+
+def test_minmax_cap_none_consumes_entire_stream():
+    """Default (None) keeps the whole-stream behavior."""
+    node = MinMaxNormalizer(use_running_stats=True)
+
+    def data_iterator():
+        yield {"data": torch.zeros(2, 4, 4, 1)}
+        yield {"data": torch.full((2, 4, 4, 1), 7.0)}
+
+    node.statistical_initialization(data_iterator())
+    assert float(node.running_max) == pytest.approx(7.0)
+    assert float(node.running_min) == pytest.approx(0.0)
+
+
+def test_minmax_cap_rejects_non_positive():
+    with pytest.raises(ValueError, match="max_initialization_frames"):
+        MinMaxNormalizer(use_running_stats=True, max_initialization_frames=0)
+    with pytest.raises(ValueError, match="max_initialization_frames"):
+        MinMaxNormalizer(use_running_stats=True, max_initialization_frames=-5)
+
+
+def test_minmax_cap_recorded_in_hparams():
+    """The cap is a declared hparam, so it round-trips through pipeline serialization."""
+    node = MinMaxNormalizer(use_running_stats=True, max_initialization_frames=20)
+    assert node.hparams["max_initialization_frames"] == 20
+
+
 @pytest.mark.parametrize(
     ("node_name", "factory"),
     [


### PR DESCRIPTION
## What

`MinMaxNormalizer` gains `max_initialization_frames: int | None = None`. When set, `statistical_initialization` consumes at most that many frames: the final batch is sliced to the cap and the input stream is not iterated further. Default `None` keeps the whole-stream behavior unchanged. Non-positive values raise `ValueError`.

## Why

The kwarg has been passed by downstream configs since the dinomaly examples were authored against core 0.8.0, but it was never a real parameter: it fell into `**kwargs` and was recorded as an inert hparam, so min/max statistics were silently computed over the entire training stream regardless. Tracked in cubert-hyperspectral/cuvis-ai-dinomaly#9.

Implementing it under the exact name already in the wild makes existing configs take effect with zero churn: the shipped `dinomaly_rgb` / `dinomaly_cir` presets (`max_initialization_frames: 20`) and the dinomaly plugin's trainrun configs, example scripts, and lentils notebooks.

Note the behavior change for those presets: statistical init now uses the first 20 frames (the setting's stated intent) instead of the whole stream. Since global min/max over fewer frames can only shrink the range, outputs may exceed [0, 1] slightly for frames outside the init window; that was the accepted trade-off when the knob was introduced downstream.

Safe node-locally: `StatisticalTrainer.fit` builds a fresh per-node input stream, so stopping early cannot starve another node's initialization.

The root cause (unknown node kwargs silently folded into hparams) is a core-side gap; a guard proposal is being filed against cuvis-ai-core separately.

## Tests

`tests/training/test_statistical_initialization.py`: the cap slices the final batch and stops pulling the stream (extreme post-cap values never reach min/max, and the generator is provably not advanced past the cap), the default consumes the whole stream, non-positive caps raise, and the cap round-trips through hparams. 30 passed together with the existing minmax suite; ruff clean.
