### PR TITLE
release: cuvis-ai 0.13.3 (dataloader v0.6.1 RLE-segmentation fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.3 - 2026-08-27
+
+- Bumped the `cuvis_ai_dataloader` manifest pin v0.6.0 -> v0.6.1: composed child environments could resolve dataclass-wizard >= 1.0 through the open floor and then silently rasterize every RLE-object COCO `segmentation` to 0 px (lost ground truth); 0.6.1 carries the payload verbatim on every wizard version, fails loudly on unrecognized payloads, and caps `dataclass-wizard<1.0` in the `coco` extra.
+- Bumped the `cuvis_ai_builtin` manifest pin v0.13.1 -> v0.13.2 so composed child environments install the released cuvis-ai matching the host.
+
 ## 0.13.2 - 2026-08-26
 
 - `MinMaxNormalizer` now implements `max_initialization_frames: int | None = None`: `statistical_initialization` consumes at most that many frames (slicing the final batch and stopping the stream early) instead of always scanning the whole training stream. The kwarg was previously swallowed into hparams as a silent no-op, so configs that already set it (the shipped `dinomaly_rgb` / `dinomaly_cir` presets with `max_initialization_frames: 20`, and the dinomaly plugin's trainrun configs and notebooks) now take effect.

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -9,7 +9,7 @@
 name: cuvis_ai_builtin
 package_name: cuvis-ai
 repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
-tag: "v0.13.1"
+tag: "v0.13.2"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform

--- a/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.6.0"
+tag: "v0.6.1"
 package_name: cuvis-ai-dataloader
 capabilities:
   - class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule


### PR DESCRIPTION
Patch release train:

- `cuvis_ai_dataloader` manifest pin v0.6.0 -> v0.6.1: composed child environments could resolve dataclass-wizard >= 1.0 through the open floor and then silently rasterize every RLE-object COCO `segmentation` to 0 px (lost ground truth). 0.6.1 (`cubert-hyperspectral/cuvis-ai-dataloader#24`) carries the payload verbatim on every wizard version, fails loudly on unrecognized payloads, and caps `dataclass-wizard<1.0` in the `coco` extra.
- `cuvis_ai_builtin` manifest pin v0.13.1 -> v0.13.2 (post-release catch-up).
- CHANGELOG stamped `## 0.13.3 - 2026-08-27`.

Tag `v0.13.3` follows after merge.