### PR TITLE
release: cuvis-ai 0.13.5 (Thor/aarch64 plugin sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.13.5 - 2026-08-31
+
+- Thor/aarch64 plugin sweep. Bumped the `sam3` manifest pin v0.3.2 -> v0.3.3: decord 0.6.0 ships no aarch64 wheel and no sdist, so the sam3 child environment failed to install on Jetson Thor; v0.3.3 gates the dependency to the platforms decord ships wheels for (only upstream video-file loaders import it, the nodes and REST API use the cv2 path).
+- Bumped the `cuvis_ai_dataloader` pin v0.6.1 -> v0.6.2, `augment` v0.4.1 -> v0.4.2, `cuvis_ai_inspecscrap` v0.2.3 -> v0.2.4, and `wafer_thickness` v0.3.0 -> v0.3.1: these four still carried the unscoped torch cu128 index pin that 0.13.4 removed from cuvis-ai itself, so any composed child environment declaring them failed with conflicting torch indexes on non-cu128 hosts (Jetson Thor, cu130). All four now scope the pin to a `cuda` dependency group, which consumers never install.
+- Bumped the `cuvis_ai_builtin` pin v0.13.4 -> v0.13.5 so composed child environments install this release.
+- Remaining plugins audited for aarch64 wheel coverage of their base dependencies (wheels-only resolution for `aarch64-manylinux_2_39`): dinomaly v0.6.2, adaclip v0.3.1, deepeiou v0.2.2, trackeval v0.1.4, and ultralytics v0.1.4 are clean; decord was the only wheel gap across the catalog. The dataloader `[cu3s]` extra still requires cuvis-il, which has no aarch64 build.
+
 ## 0.13.4 - 2026-08-27
 
 - Scoped the torch / torchvision cu128 index pin to a `cuda` dependency group (installed by default in this checkout). uv reads a git dependency's `[tool.uv.sources]`, so the unscoped pin reached every composed child environment through the `cuvis_ai_builtin` manifest and made `uv lock` fail with conflicting torch indexes on any host whose torch is not cu128 (Jetson Thor, cu130); every pipeline failed there, not only RTSAM2. CuvisNEXT's managed environment picks this up once its env spec moves to cuvis-ai-schemas 0.10 / cuvis-ai-core 0.13+.

--- a/cuvis_ai/configs/plugins/augment.yaml
+++ b/cuvis_ai/configs/plugins/augment.yaml
@@ -8,7 +8,7 @@ name: augment
 # Local development override (optional):
 # path: "../../../cuvis-ai-augment"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-augment.git"
-tag: "v0.4.1"
+tag: "v0.4.2"
 package_name: "cuvis-ai-augment"
 capabilities:
 - class_name: cuvis_ai_augment.node.compose.AugmentationCompose

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -9,7 +9,7 @@
 name: cuvis_ai_builtin
 package_name: cuvis-ai
 repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
-tag: "v0.13.4"
+tag: "v0.13.5"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform

--- a/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.6.1"
+tag: "v0.6.2"
 package_name: cuvis-ai-dataloader
 capabilities:
   - class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule

--- a/cuvis_ai/configs/plugins/cuvis_ai_inspecscrap.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_inspecscrap.yaml
@@ -4,7 +4,7 @@
 # Generic colourise/overlay/cleanup viz nodes live in the cuvis-ai node catalog, not here.
 name: cuvis_ai_inspecscrap
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-inspecscrap.git"
-tag: "v0.2.3"
+tag: "v0.2.4"
 package_name: cuvis-ai-inspecscrap
 capabilities:
   - { class_name: cuvis_ai_inspecscrap.node.data.TiffDataNode,                          category: source,    tags: [hyperspectral] }

--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.3.2"  # torch uv-index tables clarified as local-dev-only
+tag: "v0.3.3"  # decord gated to platforms with wheels (aarch64 child envs compose)
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation

--- a/cuvis_ai/configs/plugins/wafer_thickness.yaml
+++ b/cuvis_ai/configs/plugins/wafer_thickness.yaml
@@ -6,7 +6,7 @@
 
 name: wafer_thickness
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-wafer-thickness.git"
-tag: "v0.3.0"
+tag: "v0.3.1"
 package_name: "cuvis-ai-wafer-thickness"
 capabilities:
 - class_name: cuvis_ai_wafer_thickness.node.wafer_segmentation.WaferSegmentation


### PR DESCRIPTION
## What

Manifest pin bumps closing out the Jetson Thor / aarch64 child-env composition work:

- `sam3` v0.3.2 -> **v0.3.3**: decord 0.6.0 has no aarch64 wheel and no sdist, so the sam3 child env failed `uv sync` on Thor; v0.3.3 gates the dependency to the platforms decord ships wheels for (only upstream video-file loaders import it; nodes and REST API use the cv2 path). Verified on the Thor devkit: sam3 composes and loads in CuvisNEXT with this tag.
- `cuvis_ai_dataloader` v0.6.1 -> **v0.6.2**, `augment` v0.4.1 -> **v0.4.2**, `cuvis_ai_inspecscrap` v0.2.3 -> **v0.2.4**, `wafer_thickness` v0.3.0 -> **v0.3.1**: these four still carried the unscoped torch cu128 index pin that 0.13.4 removed from cuvis-ai itself; each now scopes it to a `cuda` dependency group (consumers never install a dependency''s groups).
- `cuvis_ai_builtin` v0.13.4 -> **v0.13.5** self-pin.

Remaining plugins audited for aarch64 wheel coverage of their base dependencies (wheels-only resolution for `aarch64-manylinux_2_39`): dinomaly v0.6.2, adaclip v0.3.1, deepeiou v0.2.2, trackeval v0.1.4, ultralytics v0.1.4 are clean; decord was the only wheel gap in the catalog. The dataloader `[cu3s]` extra still requires cuvis-il (no aarch64 build).

## Verification

- All five referenced tags exist with green release workflows (dataloader 0.6.2 live on PyPI).
- On-device: sam3 pipeline composes and loads in CuvisNEXT on the Thor with the v0.3.3 manifest.