### PR TITLE
release: cuvis-ai 0.13.6 (dinomaly v0.6.3 anomaly-map alignment, ValNormalAnomalyMean capability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.13.6 - 2026-08-31
 
 - Bumped the `dinomaly` manifest pin v0.6.2 -> v0.6.3: `DinomalyDetector` now aligns the returned anomaly map to the input pixel grid (new `align_map_to_input` hparam, default on), removing the radially outward shift caused by anomalib's `align_corners=True` patch upsample (up to ~12 px at the frame edge at 448). Score values are unchanged, only where they land; a deployed decider `image_threshold` tuned on the old maps is worth a re-check, and `align_map_to_input: false` reproduces the previous behaviour. No port or dependency changes.
+- Added `ValNormalAnomalyMean` to the `dinomaly` manifest capabilities: the label-free monitoring metric (running mean of the image-level `anomaly_score` per stage/epoch, shipped by the plugin since v0.6.0) was missing from this repo's copy of the manifest, so it never appeared in the node catalog. Entry generated with `scripts/emit_metadata` (category `metric`, tags `[anomaly, evaluation]`); the regeneration also normalized the embedded `icon_svg` strings of the four existing entries from CRLF to LF, so `emit_metadata --check` passes again.
+- Bumped the `cuvis_ai_builtin` pin v0.13.5 -> v0.13.6 so composed child environments install this release.
 
 ## 0.13.5 - 2026-08-31
 

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -9,7 +9,7 @@
 name: cuvis_ai_builtin
 package_name: cuvis-ai
 repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
-tag: "v0.13.5"
+tag: "v0.13.6"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform

--- a/cuvis_ai/configs/plugins/dinomaly.yaml
+++ b/cuvis_ai/configs/plugins/dinomaly.yaml
@@ -14,7 +14,7 @@ capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector
   category: model
   tags: [anomaly, hyperspectral, learnable, reconstruction, torch]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#4E7BD4\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <circle cx=\"14\" cy=\"20\" r=\"3\"/>\r\n  <circle cx=\"14\" cy=\"32\" r=\"3\"/>\r\n  <circle cx=\"14\" cy=\"44\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"16\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"32\" r=\"3\"/>\r\n  <circle cx=\"32\" cy=\"48\" r=\"3\"/>\r\n  <circle cx=\"50\" cy=\"26\" r=\"3\"/>\r\n  <circle cx=\"50\" cy=\"38\" r=\"3\"/>\r\n  <path d=\"M17 20l12-4M17 32l12-16M17 44l12-28\"/>\r\n  <path d=\"M17 20l12 12M17 32l12 0M17 44l12-12\"/>\r\n  <path d=\"M17 20l12 28M17 32l12 16M17 44l12 4\"/>\r\n  <path d=\"M35 16l12 10M35 32l12-6M35 48l12-22\"/>\r\n  <path d=\"M35 16l12 22M35 32l12 6M35 48l12-10\"/>\r\n</svg>\r\n"
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#4E7BD4\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <circle cx=\"14\" cy=\"20\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"14\" cy=\"44\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"16\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"32\" r=\"3\"/>\n  <circle cx=\"32\" cy=\"48\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"26\" r=\"3\"/>\n  <circle cx=\"50\" cy=\"38\" r=\"3\"/>\n  <path d=\"M17 20l12-4M17 32l12-16M17 44l12-28\"/>\n  <path d=\"M17 20l12 12M17 32l12 0M17 44l12-12\"/>\n  <path d=\"M17 20l12 28M17 32l12 16M17 44l12 4\"/>\n  <path d=\"M35 16l12 10M35 32l12-6M35 48l12-22\"/>\n  <path d=\"M35 16l12 22M35 32l12 6M35 48l12-10\"/>\n</svg>\n"
   input_specs:
     rgb_image:
       dtype: float32
@@ -41,7 +41,7 @@ capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_train_loss_bridge.DinomalyTrainLossBridge
   category: loss
   tags: [differentiable, torch, training]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#9A5DD4\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M10 14v40h44\"/>\r\n  <path d=\"M14 18c8 0 12 8 18 18s12 14 22 14\"/>\r\n  <path d=\"M48 44l6 6-6 6\" transform=\"translate(0 -6)\"/>\r\n</svg>\r\n"
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#9A5DD4\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <path d=\"M14 18c8 0 12 8 18 18s12 14 22 14\"/>\n  <path d=\"M48 44l6 6-6 6\" transform=\"translate(0 -6)\"/>\n</svg>\n"
   input_specs:
     raw_loss:
       dtype: float32
@@ -58,7 +58,7 @@ capabilities:
 - class_name: cuvis_ai_dinomaly.node.auroc_metrics.AnomalyAUROCMetrics
   category: metric
   tags: [anomaly, evaluation]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M10 14v40h44\"/>\r\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\r\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\r\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\r\n</svg>\r\n"
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\n</svg>\n"
   input_specs:
     scores:
       dtype: float32
@@ -85,7 +85,7 @@ capabilities:
 - class_name: cuvis_ai_dinomaly.node.per_class_auroc.PerClassAnomalyAUROC
   category: metric
   tags: [anomaly, evaluation]
-  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\r\n  <path d=\"M10 14v40h44\"/>\r\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\r\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\r\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\r\n</svg>\r\n"
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\n</svg>\n"
   input_specs:
     scores:
       dtype: float32
@@ -104,3 +104,20 @@ capabilities:
       optional: false
       description: List of Metric objects (running per-class AUROC)
   doc_summary: Streaming one-vs-background pixel AUROC per class (val/test only).
+- class_name: cuvis_ai_dinomaly.node.val_anomaly_mean.ValNormalAnomalyMean
+  category: metric
+  tags: [anomaly, evaluation]
+  icon_svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 64 64\" fill=\"none\" stroke=\"#C9615A\" stroke-width=\"2.5\" stroke-linecap=\"round\" stroke-linejoin=\"round\">\n  <path d=\"M10 14v40h44\"/>\n  <rect x=\"16\" y=\"38\" width=\"8\" height=\"12\"/>\n  <rect x=\"28\" y=\"28\" width=\"8\" height=\"22\"/>\n  <rect x=\"40\" y=\"18\" width=\"8\" height=\"32\"/>\n</svg>\n"
+  input_specs:
+    anomaly_score:
+      dtype: float32
+      shape: [-1]
+      optional: false
+      description: Per-image anomaly score [B]
+  output_specs:
+    metrics:
+      dtype: ''
+      shape: []
+      optional: false
+      description: List of Metric objects (running mean_anomaly_normal)
+  doc_summary: Running mean of the image-level ``anomaly_score`` per ``(stage, epoch)``.


### PR DESCRIPTION
Release train for 0.13.6. Contents since v0.13.5:

- dinomaly manifest pin v0.6.2 -> v0.6.3 (already on main): DinomalyDetector aligns the returned anomaly map to the input pixel grid (new align_map_to_input hparam, default on), removing the radially outward shift from anomalib's align_corners=True patch upsample. Deployed decider image_thresholds tuned on the old maps are worth a re-check; align_map_to_input: false reproduces the previous behaviour.
- Added ValNormalAnomalyMean to the dinomaly manifest capabilities: the label-free monitoring metric shipped by the plugin since v0.6.0 was missing from this repo's copy, so it never appeared in the node catalog. Entry generated with scripts/emit_metadata; the regen also normalized the four existing entries' embedded icon_svg strings from CRLF to LF, so emit_metadata --check passes again.
- cuvis_ai_builtin pin v0.13.5 -> v0.13.6 so composed child environments install this release.

After squash-merge: tag v0.13.6 on main; the tag push triggers pypi-release.yml (PyPI publish + GitHub release).