### PR TITLE
Add LogitsToClassMap built-in node (argmax seg logits -> class_map)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.8 - 2026-08-31
+
+- Added `LogitsToClassMap` built-in node (`cuvis_ai.node.conversion.LogitsToClassMap`): per-pixel `argmax` of segmentation logits `[B, H, W, num_classes]` into a discrete class-index map `[B, H, W]` (int32, 0 = background). It is the same prediction used to score segmentation IoU (`SegMetrics` foreground = `argmax >= 1`) and the `class_map` producer the existing `ClassMapRobustifier` / `ClassMapToRGB` consumers previously lacked, so a multiclass segmentation head's output is now directly displayable (single channel) instead of raw multi-channel logits. Added to the `cuvis_ai_builtin` manifest.
+
 ## 0.13.6 - 2026-08-31
 
 - Bumped the `dinomaly` manifest pin v0.6.2 -> v0.6.3: `DinomalyDetector` now aligns the returned anomaly map to the input pixel grid (new `align_map_to_input` hparam, default on), removing the radially outward shift caused by anomalib's `align_corners=True` patch upsample (up to ~12 px at the frame edge at 448). Score values are unchanged, only where they land; a deployed decider `image_threshold` tuned on the old maps is worth a re-check, and `align_map_to_input: false` reproduces the previous behaviour. No port or dependency changes.

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -1090,6 +1090,21 @@ capabilities:
       optional: false
       description: Zoomed RGB frames [B, zoom_height, zoom_width, 3] in [0, 1].
   doc_summary: Crop a region defined by a bbox and resize it to a fixed output frame.
+- class_name: cuvis_ai.node.conversion.LogitsToClassMap
+  category: transform
+  tags: [postprocessing, segmentation, torch]
+  input_specs:
+    logits:
+      dtype: float32
+      shape: [-1, -1, -1, -1]
+      optional: false
+      description: Per-pixel class logits [B, H, W, num_classes]
+  output_specs:
+    class_map:
+      dtype: int32
+      shape: [-1, -1, -1]
+      optional: false
+      description: Per-pixel argmax class index [B, H, W]; 0=first/background class
 - class_name: cuvis_ai.node.conversion.DecisionToMask
   category: transform
   tags: [mask, postprocessing, torch]

--- a/cuvis_ai/node/__init__.py
+++ b/cuvis_ai/node/__init__.py
@@ -60,7 +60,7 @@ from cuvis_ai.node.compositing import (
     ROIZoomNode,
     TitleOverlay,
 )
-from cuvis_ai.node.conversion import DecisionToMask
+from cuvis_ai.node.conversion import DecisionToMask, LogitsToClassMap
 from cuvis_ai.node.deciders import (
     BinaryDecider,
     MultiRangeSlicer,
@@ -173,6 +173,7 @@ __all__ = [
     "DetectionCocoJsonNode",
     "DetectionJsonReader",
     "DecisionToMask",
+    "LogitsToClassMap",
     "DiceLoss",
     "DisplayNormalizer",
     "DistinctnessLoss",

--- a/cuvis_ai/node/conversion.py
+++ b/cuvis_ai/node/conversion.py
@@ -257,3 +257,42 @@ class DecisionToMask(Node):
         """Apply decisions to identities and return the final segmentation mask."""
         mask = identity_mask.to(torch.int32) * decisions.squeeze(-1).to(torch.int32)
         return {"mask": mask}
+
+
+class LogitsToClassMap(Node):
+    """Per-pixel argmax of segmentation logits into an integer class map.
+
+    Converts a segmentation head's per-pixel class logits ``[B, H, W, num_classes]`` into
+    the discrete class-index map ``[B, H, W]`` (``argmax`` over the class axis) — the same
+    prediction used to score segmentation IoU (foreground ``= argmax >= 1``). Class ``0`` is
+    background. This is the ``class_map`` producer that ``ClassMapRobustifier`` and
+    ``ClassMapToRGB`` consume, and it makes a multiclass segmentation head's output directly
+    displayable (single channel) instead of the raw multi-channel logits.
+
+    Pure and deterministic; ``argmax`` is non-differentiable, so this node does not
+    participate in gradient training (place it after the loss branch, for inference/display).
+    """
+
+    _category = NodeCategory.TRANSFORM
+    _tags = frozenset({NodeTag.SEGMENTATION, NodeTag.POSTPROCESSING, NodeTag.TORCH})
+
+    INPUT_SPECS = {
+        "logits": PortSpec(
+            dtype=torch.float32,
+            shape=(-1, -1, -1, -1),
+            description="Per-pixel class logits [B, H, W, num_classes]",
+        )
+    }
+
+    OUTPUT_SPECS = {
+        "class_map": PortSpec(
+            dtype=torch.int32,
+            shape=(-1, -1, -1),
+            description="Per-pixel argmax class index [B, H, W]; 0=first/background class",
+        )
+    }
+
+    @torch.no_grad()
+    def forward(self, logits: torch.Tensor, **_) -> dict[str, torch.Tensor]:
+        """Return the per-pixel argmax class index over the last (class) axis."""
+        return {"class_map": logits.argmax(dim=-1).to(torch.int32)}

--- a/tests/node/test_logits_to_class_map.py
+++ b/tests/node/test_logits_to_class_map.py
@@ -1,0 +1,38 @@
+"""Tests for LogitsToClassMap: per-pixel argmax of segmentation logits."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from cuvis_ai.node.conversion import LogitsToClassMap
+
+pytestmark = pytest.mark.unit
+
+
+def test_argmax_matches_handbuilt_and_torch():
+    """class_map is the per-pixel argmax over the class axis (golden reference)."""
+    # [B=1, H=1, W=3, C=3]: winners are classes 0, 2, 1.
+    logits = torch.tensor([[[[2.0, 1.0, 0.5], [0.1, 0.2, 5.0], [0.0, 3.0, 1.0]]]])
+    out = LogitsToClassMap().forward(logits=logits)["class_map"]
+
+    assert torch.equal(out, torch.tensor([[[0, 2, 1]]], dtype=torch.int32))
+    assert torch.equal(out, logits.argmax(dim=-1).to(torch.int32))
+
+
+def test_port_contract_shape_and_dtype():
+    """Output drops the class axis -> [B, H, W] int32."""
+    out = LogitsToClassMap().forward(logits=torch.randn(2, 4, 5, 3))["class_map"]
+
+    assert out.shape == (2, 4, 5)
+    assert out.dtype == torch.int32
+    assert int(out.max()) <= 2 and int(out.min()) >= 0
+
+
+def test_two_class_equals_foreground_probability_half():
+    """For 2 classes, argmax == (P(shell) >= 0.5) -- the SegMetrics foreground rule."""
+    logits = torch.randn(1, 8, 8, 2)
+    class_map = LogitsToClassMap().forward(logits=logits)["class_map"]
+    fg_by_prob = (torch.softmax(logits, dim=-1)[..., 1] >= 0.5).to(torch.int32)
+
+    assert torch.equal(class_map, fg_by_prob)


### PR DESCRIPTION
## What
Adds a built-in node **`LogitsToClassMap`** (`cuvis_ai.node.conversion.LogitsToClassMap`): per-pixel `argmax` of segmentation logits `[B, H, W, num_classes]` → discrete class-index map `[B, H, W]` (int32, `0` = background).

## Why
The catalog has `class_map` **consumers** — `ClassMapRobustifier` (mask_ops) and `ClassMapToRGB` (colormap) — but **no producer** from segmentation logits. A multiclass segmentation head (e.g. DynUNet) only emits multi-channel `logits`, which can't be displayed as a single-channel value map and can't feed those consumers. Downstream this surfaced as an `OpenCV CV_32FC1` assertion when trying to display raw logits in cuvis.next.

This node closes that gap and matches the prediction already used to score IoU: `SegMetrics` computes foreground as `logits.argmax(-1) >= 1`, so `LogitsToClassMap` reproduces the exact training/eval prediction for any number of classes.

## Change
- `LogitsToClassMap` in `cuvis_ai/node/conversion.py` (stateless, pure, `@torch.no_grad`, `TRANSFORM` / `[postprocessing, segmentation, torch]`).
- Exported from `cuvis_ai/node/__init__.py`; added to the `cuvis_ai_builtin` manifest.
- Test `tests/node/test_logits_to_class_map.py`: golden-reference argmax, port contract (`[B,H,W]` int32), and the 2-class `argmax == P(fg)>=0.5` equivalence.
- CHANGELOG `0.13.8` (0.13.7 is reserved by the open unet-manifest PR #86; adjust ordering on merge as needed).

## Verification
`pytest tests/node/test_logits_to_class_map.py tests/plugins/test_builtin_manifest_sync.py tests/docs/test_node_catalog.py` → **16 passed**. ruff format + check clean. Manifest loads (153 capabilities). Node is stateless (no buffers/hparams) so serialization round-trip is trivial, same pattern as its sibling `DecisionToMask`.
