### PR TITLE
release: cuvis-ai 0.15.1 (decider calibrate(), shared threshold sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
-## 0.15.0 - unreleased
+## 0.15.1 - 2026-09-04
+
+- `BinaryDecider`, `QuantileBinaryDecider` and `TwoStageBinaryDecider` gain `calibrate(scores, targets)`: re-fit the decider's own decision rule to F1-max on a labelled validation split, written to the live attribute and to `hparams`, so the saved pipeline yaml carries the value (the `.pt` is unchanged). This is the node half of the in-training calibration phase; the trainrun hook lands in cuvis-ai-core.
+- The F1-max sweep math moved from `scripts/calibrate_thresholds.py` into the shared `cuvis_ai/node/deciders/_calibration.py`; the CLI and the new methods run the same code and report the same values.
+- Calibrated thresholds are exact in float32 (the space the deciders compare in) and sit at the midpoint of the F1-max plateau instead of on a validation sample; the two-stage gate reuses the exact stage-1 statistic of `forward`.
+- `BinaryDecider` calibration sweeps float32 sigmoid probabilities directly, so saturated logits no longer map to an unreachable threshold; the CLI binary mode follows.
+- `CalibrationError` (a `ValueError`) names the bad input: mismatched shapes, non-finite scores, single-class targets, or a `QuantileBinaryDecider.reduce_dims` the sweep cannot honour.
+- The sweeps count true and false positives for all candidates in one pass per frame (sorted scores plus `searchsorted`), so calibration on a large validation split no longer scans every pixel once per candidate.
+
+## 0.15.0 - 2026-09-04
 
 - **Plugin model weights come from the public `cubert-gmbh` Hugging Face mirrors; no Hugging Face account or token is needed any more.** The manifest pins move to the plugin releases that resolve their weights through the cuvis-ai-core 0.16.0 registry: `sam3` v0.4.0 (SAM3 checkpoint from `cubert-gmbh/sam3`), `rtsam2` v0.4.0 (EfficientTAM from `cubert-gmbh/efficient-track-anything`, now including the 512x512 variants), `adaclip` v0.4.0 (CLIP backbone and AdaCLIP heads from `cubert-gmbh/clip` and `cubert-gmbh/adaclip`, `gdown` dropped) and `dinomaly` v0.7.0 (DINOv2 backbone from `cubert-gmbh/dinov2`). Core floor raised to `cuvis-ai-core>=0.16.0`. The cache folder names change (`models--cubert-gmbh--*`), so an existing install downloads its weights once more; `uv run download-model download <name>` provisions them ahead of an offline gRPC run.
 - **New docs page [Model Weights](docs/workflows/model-weights.md)**: which weights each plugin downloads, `download-model list` and `download` usage, provisioning for the offline child runtime, custom or private weights, and the licence of every mirrored file. `.env.example` now says `HF_TOKEN` is only needed for private or custom repos.

--- a/cuvis_ai/node/deciders/_calibration.py
+++ b/cuvis_ai/node/deciders/_calibration.py
@@ -11,15 +11,30 @@ sweep is dispatched on the decider class:
   frame killed by the gate contributes all-zero pixels - so the grid is joint.
 
 - binary: a single sweep over an absolute elementwise cutoff. ``BinaryDecider`` thresholds
-  ``sigmoid(logits)``, so the sweep runs in raw space and the caller maps the optimum
-  through sigmoid.
+  ``sigmoid(logits)`` in float32, so the caller hands in those probabilities and the sweep
+  runs in the exact space ``forward`` compares in.
 
 - quantile: a single sweep over the per-frame adaptive ``quantile``; the decider recomputes
   its cutoff from each frame's own scores, so the sweep fixes the flagged-pixel fraction
   rather than an absolute threshold.
 
-All functions are numpy-based and free of any pipeline / node state, so both the in-training
-calibration phase and the offline ``calibrate-thresholds`` CLI call the same code.
+Numerics, so that what the sweep scores is what ``forward`` decides:
+
+- Pixel-level thresholds are compared in float32 at runtime (``TwoStageBinaryDecider`` casts
+  ``pixel_threshold`` to the score dtype, ``BinaryDecider`` compares float32 probabilities
+  against a Python float that torch casts to float32). Candidates are therefore float32 values
+  and the per-frame counts use ``searchsorted`` on float32 arrays: exact, and one pass per
+  frame instead of one pass per candidate.
+
+- The image gate compares two Python floats (``image_score`` comes from ``.item()``), so image
+  thresholds stay float64. ``frame_image_score`` is the very statistic ``forward`` computes.
+
+- F1 ties resolve to the highest candidate (the most restrictive threshold), then the
+  applied value steps down to the midpoint of the F1 plateau (``margin_below``): same
+  validation F1, a real margin against near-duplicate scores at deployment.
+
+All functions are free of pipeline / node state, so both the in-training calibration phase
+and the offline ``calibrate-thresholds`` CLI call the same code.
 """
 
 from __future__ import annotations
@@ -31,6 +46,62 @@ import numpy as np
 import torch
 
 
+class CalibrationError(ValueError):
+    """Raised when a decider cannot be calibrated on the given scores and targets.
+
+    Covers unusable data (shape mismatch, non-finite scores, a single-class split) and a
+    decider configuration whose decision rule the sweep cannot reproduce (a ``reduce_dims``
+    that keeps a real channel axis out of the quantile). A caller that runs calibration as an
+    optional phase catches this, logs it, and leaves the shipped thresholds untouched.
+    """
+
+
+def topk_count(numel: int, top_k_fraction: float) -> int:
+    """``k`` for the stage-1 image score: ``ceil(top_k_fraction * numel)``, at least 1.
+
+    The product is rounded to float32 before the ceiling, exactly as
+    ``TwoStageBinaryDecider.forward`` does, so a float64 product that lands epsilon above an
+    integer does not add a pixel.
+    """
+    return max(
+        1,
+        int(torch.ceil(torch.tensor(numel * top_k_fraction, dtype=torch.float32)).item()),
+    )
+
+
+def frame_image_score(pixel_scores: torch.Tensor, top_k_fraction: float) -> float:
+    """Stage-1 image score of one frame: mean of the top-k per-pixel scores.
+
+    This is the statistic ``TwoStageBinaryDecider.forward`` gates on, shared so calibration
+    and runtime agree bit for bit. ``pixel_scores`` is the frame's ``[H, W]`` per-pixel score
+    map (already reduced over channels).
+    """
+    flat = pixel_scores.reshape(-1)
+    k = topk_count(flat.numel(), top_k_fraction)
+    return torch.topk(flat, k).values.mean().item()
+
+
+def topk_mean_scores(pixel_scores: np.ndarray, top_k_fraction: float) -> np.ndarray:
+    """Stage-1 image score per frame for stacked ``[N, H, W]`` pixel scores (float64).
+
+    Delegates to :func:`frame_image_score` frame by frame, so the values are the ones
+    ``forward`` will compute, widened to float64 the way ``.item()`` widens them.
+    """
+    frames = torch.from_numpy(np.ascontiguousarray(pixel_scores, dtype=np.float32))
+    return np.asarray(
+        [frame_image_score(frame, top_k_fraction) for frame in frames], dtype=np.float64
+    )
+
+
+def sigmoid_float32(values: np.ndarray) -> np.ndarray:
+    """``torch.sigmoid`` in float32: the probabilities ``BinaryDecider.forward`` thresholds.
+
+    Computed with torch rather than numpy so the CLI and the decider see identical values,
+    including the saturation to exactly ``1.0`` above logits of roughly 17.
+    """
+    return torch.sigmoid(torch.from_numpy(np.ascontiguousarray(values, dtype=np.float32))).numpy()
+
+
 def reduce_scores_targets(
     scores: torch.Tensor, targets: torch.Tensor
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -38,17 +109,47 @@ def reduce_scores_targets(
 
     ``scores`` is the decider-input tensor stacked over the split, ``[N, H, W, C]`` (or
     ``[N, H, W]``); ``targets`` the ground-truth mask, bool-ish ``[N, H, W, C]`` or
-    ``[N, H, W]``. Returns ``(full_scores[N,H,W,C], pixel_scores[N,H,W],
+    ``[N, H, W]``. Returns ``(full_scores[N,H,W,C] float32, pixel_scores[N,H,W] float32,
     gt_masks[N,H,W] bool, frame_labels[N] bool)``. ``pixel_scores`` is the per-pixel max
     over channels - the same reduction the deciders apply in ``forward`` - and
     ``full_scores`` is kept for the per-frame quantile probes.
+
+    Raises:
+        CalibrationError: when the shapes disagree, a score is nan or inf (a threshold fitted
+            on it would be refused when the yaml is loaded), or the targets are single-class
+            (no anomalous pixel, or nothing but anomalous pixels), which no threshold can fit.
     """
+    if scores.dim() not in (3, 4):
+        raise CalibrationError(
+            f"scores must be [N, H, W] or [N, H, W, C], got shape {tuple(scores.shape)}"
+        )
+    if targets.dim() not in (3, 4):
+        raise CalibrationError(
+            f"targets must be [N, H, W] or [N, H, W, C], got shape {tuple(targets.shape)}"
+        )
+    if tuple(scores.shape[:3]) != tuple(targets.shape[:3]):
+        raise CalibrationError(
+            f"scores {tuple(scores.shape)} and targets {tuple(targets.shape)} disagree on "
+            "[N, H, W]; every frame needs its own ground-truth mask"
+        )
     full = scores.detach().to("cpu", torch.float32).numpy()
     if full.ndim == 3:
         full = full[..., None]
+    if not np.isfinite(full).all():
+        raise CalibrationError(
+            "scores contain nan or inf; a threshold fitted on them could not be loaded back"
+        )
     pixel = full.max(axis=-1)
     gt = targets.detach().to("cpu").numpy()
     gt = (gt.any(axis=-1) if gt.ndim == 4 else gt).astype(bool)
+    if not gt.any():
+        raise CalibrationError(
+            "targets mark no anomalous pixel; a single-class split cannot calibrate a threshold"
+        )
+    if gt.all():
+        raise CalibrationError(
+            "targets mark every pixel anomalous; a single-class split cannot calibrate a threshold"
+        )
     frame_labels = gt.any(axis=(1, 2))
     return full, pixel, gt, frame_labels
 
@@ -87,33 +188,69 @@ def binary_auroc(scores: np.ndarray, labels: np.ndarray) -> float:
     return float(u_statistic / (positives * negatives))
 
 
-def sigmoid(values: np.ndarray | float) -> Any:
-    """Numerically plain sigmoid; raw anomaly scores are small in practice."""
-    return 1.0 / (1.0 + np.exp(-np.asarray(values, dtype=np.float64)))
-
-
-def topk_mean_scores(pixel_scores: np.ndarray, top_k_fraction: float) -> np.ndarray:
-    """Stage-1 image score per frame: mean of the top-k fraction of pixel scores.
-
-    ``k`` replicates the decider bit-for-bit: the product is cast to float32 before ceiling
-    (``TwoStageBinaryDecider.forward``), so calibration and runtime agree even when the
-    float64 product lands epsilon above an integer.
-    """
-    flat = pixel_scores.reshape(pixel_scores.shape[0], -1)
-    k = max(1, int(np.ceil(np.float32(flat.shape[1] * top_k_fraction))))
-    top = np.partition(flat, flat.shape[1] - k, axis=1)[:, -k:]
-    return top.mean(axis=1)
-
-
 def pixel_candidates(pixel_scores: np.ndarray, num_candidates: int) -> np.ndarray:
-    """Absolute-threshold candidates from pooled score quantiles.
+    """Absolute-threshold candidates from pooled score quantiles, exact in float32.
 
     The tail reaches ``1/pixel_scores.size`` (a single pooled pixel) so the achievable
-    precision frontier for sparse anomalies lies inside the grid.
+    precision frontier for sparse anomalies lies inside the grid. Candidates are cast to
+    float32 - the dtype the deciders compare pixel scores in - and the pooled maximum is
+    always included, so every candidate is a threshold ``forward`` applies exactly.
     """
-    tail_lo = max(1.0 / pixel_scores.size, 1e-12)
+    flat = pixel_scores.reshape(-1)
+    tail_lo = max(1.0 / flat.size, 1e-12)
     upper_tail = 1.0 - np.logspace(np.log10(tail_lo), np.log10(0.5), num_candidates)
-    return np.unique(np.quantile(pixel_scores, np.sort(upper_tail)))
+    quantiles = np.quantile(flat, np.sort(upper_tail)).astype(np.float32)
+    return np.unique(np.append(quantiles, np.float32(flat.max())))
+
+
+def margin_below(threshold: float, samples: np.ndarray, *, float32: bool) -> float:
+    """Midpoint between ``threshold`` and the largest sample strictly below it.
+
+    An F1-max sweep returns a threshold that sits on a validation sample (or on a quantile of
+    the samples). Every threshold in ``(lower_sample, threshold]`` flags the same set, so the
+    plateau midpoint keeps the validation F1 and adds a margin against near-duplicate scores
+    at deployment. With ``float32`` the midpoint is rounded to float32 (the dtype the deciders
+    compare pixel scores in) and kept only if it still separates the two samples; otherwise,
+    and when no sample lies below, ``threshold`` itself is returned.
+    """
+    threshold = float(threshold)
+    below = samples[samples < threshold]
+    if below.size == 0:
+        return threshold
+    lower = float(below.max())
+    midpoint = (threshold + lower) / 2.0
+    if float32:
+        midpoint = float(np.float32(midpoint))
+        if not lower < midpoint <= threshold:
+            return threshold
+    return midpoint
+
+
+def _count_at_or_above(sorted_values: np.ndarray, candidates: np.ndarray) -> np.ndarray:
+    """How many of the ascending ``sorted_values`` are ``>=`` each candidate."""
+    return sorted_values.size - np.searchsorted(sorted_values, candidates, side="left")
+
+
+def frame_confusions(
+    pixel_scores: np.ndarray, gt_masks: np.ndarray, candidates: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-frame true/false positive counts for every candidate, ``[N, len(candidates)]`` each.
+
+    One sort per frame and class plus a ``searchsorted`` against the candidate edges gives the
+    counts for all candidates at once; the cost no longer scales with the candidate count.
+    ``pixel_scores`` and ``candidates`` must share a dtype (float32) so the comparison is exact.
+    """
+    n_frames = pixel_scores.shape[0]
+    flat_scores = pixel_scores.reshape(n_frames, -1)
+    flat_gt = gt_masks.reshape(n_frames, -1)
+    tp = np.empty((n_frames, candidates.size), dtype=np.float64)
+    fp = np.empty_like(tp)
+    for i in range(n_frames):
+        positives = np.sort(flat_scores[i][flat_gt[i]])
+        negatives = np.sort(flat_scores[i][~flat_gt[i]])
+        tp[i] = _count_at_or_above(positives, candidates)
+        fp[i] = _count_at_or_above(negatives, candidates)
+    return tp, fp
 
 
 def quantile_grid_builder(
@@ -154,29 +291,25 @@ def sweep_two_stage(
     """2-D sweep (image gate x absolute pixel threshold) for ``TwoStageBinaryDecider``.
 
     Returns ``(best_image, joint_best, conditional_best)``; gated-out frames contribute their
-    full ground truth as misses, which is what couples the two stages.
+    full ground truth as misses, which is what couples the two stages. ``best_image`` carries
+    the on-point ``threshold`` and the plateau-midpoint ``margin_threshold``; the two pixel
+    rows carry ``pixel_threshold`` / ``margin_pixel_threshold`` and ``image_threshold`` /
+    ``margin_image_threshold``. Ties resolve to the highest threshold.
     """
+    pixel_scores = np.ascontiguousarray(pixel_scores, dtype=np.float32)
     image_candidates = np.unique(image_scores)
     image_grid = [
         {"threshold": float(thr), **image_metrics_at(image_scores, frame_labels, thr)}
         for thr in image_candidates
     ]
     best_image = max(image_grid, key=lambda row: (row["f1"], row["threshold"]))
+    best_image["margin_threshold"] = margin_below(
+        best_image["threshold"], image_scores, float32=False
+    )
 
     candidates = pixel_candidates(pixel_scores, num_candidates)
-    flat_scores = pixel_scores.reshape(len(frame_labels), -1)
-    flat_gt = gt_masks.reshape(len(frame_labels), -1)
-    not_gt = ~flat_gt
-    gt_per_frame = flat_gt.sum(axis=1).astype(np.float64)
-    # Per-frame TP/FP for every pixel candidate: [n_frames, n_candidates]
-    tp = np.empty((len(frame_labels), len(candidates)), dtype=np.float64)
-    fp = np.empty_like(tp)
-    for j, thr in enumerate(candidates):
-        flagged = flat_scores >= thr
-        tp[:, j] = (flagged & flat_gt).sum(axis=1)
-        fp[:, j] = (flagged & not_gt).sum(axis=1)
-
-    total_gt = float(gt_per_frame.sum())
+    tp, fp = frame_confusions(pixel_scores, gt_masks, candidates)
+    total_gt = float(gt_masks.sum())
     joint_best: dict[str, Any] | None = None
     conditional_best: dict[str, Any] | None = None
     for image_thr in image_candidates:
@@ -190,33 +323,49 @@ def sweep_two_stage(
                 "pixel_threshold": float(pixel_thr),
                 **prf(float(gated_tp[j]), float(gated_fp[j]), float(fn[j])),
             }
-            if joint_best is None or row["f1"] > joint_best["f1"]:
+            # ``>=``: candidates ascend, so a tie goes to the more restrictive threshold.
+            if joint_best is None or row["f1"] >= joint_best["f1"]:
                 joint_best = row
             if image_thr == best_image["threshold"] and (
-                conditional_best is None or row["f1"] > conditional_best["f1"]
+                conditional_best is None or row["f1"] >= conditional_best["f1"]
             ):
                 conditional_best = row
     assert joint_best is not None and conditional_best is not None
+    for row in (joint_best, conditional_best):
+        row["margin_image_threshold"] = margin_below(
+            row["image_threshold"], image_scores, float32=False
+        )
+        row["margin_pixel_threshold"] = margin_below(
+            row["pixel_threshold"], pixel_scores, float32=True
+        )
     return best_image, joint_best, conditional_best
 
 
 def sweep_absolute(
     pixel_scores: np.ndarray, gt_masks: np.ndarray, num_candidates: int
 ) -> dict[str, Any]:
-    """Single ungated sweep over an absolute elementwise cutoff (``BinaryDecider``)."""
+    """Single ungated sweep over an absolute elementwise cutoff (``BinaryDecider``).
+
+    ``pixel_scores`` are the values ``forward`` compares (for ``BinaryDecider`` the float32
+    sigmoid probabilities). Returns the F1-max row with the on-point ``threshold`` and the
+    plateau-midpoint ``margin_threshold``; ties resolve to the highest threshold.
+    """
+    pixel_scores = np.ascontiguousarray(pixel_scores, dtype=np.float32)
+    candidates = pixel_candidates(pixel_scores, num_candidates)
+    tp, fp = frame_confusions(pixel_scores, gt_masks, candidates)
+    tp_total = tp.sum(axis=0)
+    fp_total = fp.sum(axis=0)
     total_gt = float(gt_masks.sum())
-    not_gt = ~gt_masks
     best: dict[str, Any] | None = None
-    for thr in pixel_candidates(pixel_scores, num_candidates):
-        flagged = pixel_scores >= thr
-        tp = float((flagged & gt_masks).sum())
+    for j, thr in enumerate(candidates):
         row = {
-            "raw_threshold": float(thr),
-            **prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
+            "threshold": float(thr),
+            **prf(float(tp_total[j]), float(fp_total[j]), total_gt - float(tp_total[j])),
         }
-        if best is None or row["f1"] > best["f1"]:
+        if best is None or row["f1"] >= best["f1"]:
             best = row
     assert best is not None
+    best["margin_threshold"] = margin_below(best["threshold"], pixel_scores, float32=True)
     return best
 
 
@@ -225,7 +374,10 @@ def sweep_quantile(
     gt_masks: np.ndarray,
     frame_quantiles: dict[float, np.ndarray],
 ) -> dict[str, Any]:
-    """Sweep the per-frame adaptive ``quantile`` (``QuantileBinaryDecider``)."""
+    """Sweep the per-frame adaptive ``quantile`` (``QuantileBinaryDecider``).
+
+    Ties resolve to the highest quantile (the most restrictive cutoff).
+    """
     total_gt = float(gt_masks.sum())
     not_gt = ~gt_masks
     best: dict[str, Any] | None = None
@@ -237,7 +389,7 @@ def sweep_quantile(
             "quantile": float(q),
             **prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
         }
-        if best is None or row["f1"] > best["f1"]:
+        if best is None or row["f1"] >= best["f1"]:
             best = row
     assert best is not None
     return best

--- a/cuvis_ai/node/deciders/_calibration.py
+++ b/cuvis_ai/node/deciders/_calibration.py
@@ -1,0 +1,243 @@
+"""Threshold-calibration sweep math shared by the deciders and the calibrate CLI.
+
+A trained anomaly pipeline ships its decider with fixed threshold hparams that go stale
+per checkpoint: training moves the score distribution, so values tuned for one set of
+weights misfit the next. These functions sweep a decider's actual decision rule against
+ground truth (F1-max) so the operating point can be re-fitted on a labelled split. The
+sweep is dispatched on the decider class:
+
+- two-stage: a 2-D grid over the stage-1 image gate (mean of top-k pixel scores, raw
+  space) and an absolute stage-2 ``pixel_threshold`` (raw space). The stages couple - a
+  frame killed by the gate contributes all-zero pixels - so the grid is joint.
+
+- binary: a single sweep over an absolute elementwise cutoff. ``BinaryDecider`` thresholds
+  ``sigmoid(logits)``, so the sweep runs in raw space and the caller maps the optimum
+  through sigmoid.
+
+- quantile: a single sweep over the per-frame adaptive ``quantile``; the decider recomputes
+  its cutoff from each frame's own scores, so the sweep fixes the flagged-pixel fraction
+  rather than an absolute threshold.
+
+All functions are numpy-based and free of any pipeline / node state, so both the in-training
+calibration phase and the offline ``calibrate-thresholds`` CLI call the same code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def reduce_scores_targets(
+    scores: torch.Tensor, targets: torch.Tensor
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Reduce stacked val scores/targets to the numpy arrays the sweeps consume.
+
+    ``scores`` is the decider-input tensor stacked over the split, ``[N, H, W, C]`` (or
+    ``[N, H, W]``); ``targets`` the ground-truth mask, bool-ish ``[N, H, W, C]`` or
+    ``[N, H, W]``. Returns ``(full_scores[N,H,W,C], pixel_scores[N,H,W],
+    gt_masks[N,H,W] bool, frame_labels[N] bool)``. ``pixel_scores`` is the per-pixel max
+    over channels - the same reduction the deciders apply in ``forward`` - and
+    ``full_scores`` is kept for the per-frame quantile probes.
+    """
+    full = scores.detach().to("cpu", torch.float32).numpy()
+    if full.ndim == 3:
+        full = full[..., None]
+    pixel = full.max(axis=-1)
+    gt = targets.detach().to("cpu").numpy()
+    gt = (gt.any(axis=-1) if gt.ndim == 4 else gt).astype(bool)
+    frame_labels = gt.any(axis=(1, 2))
+    return full, pixel, gt, frame_labels
+
+
+def prf(tp: float, fp: float, fn: float) -> dict[str, float]:
+    """Precision, recall, F1 and IoU from raw counts (0 when undefined)."""
+    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
+    iou = tp / (tp + fp + fn) if tp + fp + fn > 0 else 0.0
+    return {"precision": precision, "recall": recall, "f1": f1, "iou": iou}
+
+
+def image_metrics_at(image_scores: np.ndarray, labels: np.ndarray, thr: float) -> dict[str, float]:
+    """Frame-level precision/recall/F1/IoU at one image threshold (``>=``)."""
+    flagged = image_scores >= thr
+    tp = float((flagged & labels).sum())
+    return prf(tp, float((flagged & ~labels).sum()), float((~flagged & labels).sum()))
+
+
+def binary_auroc(scores: np.ndarray, labels: np.ndarray) -> float:
+    """Exact rank-based AUROC (Mann-Whitney U) for a small sample count."""
+    positives = int(labels.sum())
+    negatives = int((~labels).sum())
+    if positives == 0 or negatives == 0:
+        return float("nan")
+    order = scores.argsort(kind="mergesort")
+    ranks = np.empty_like(order, dtype=np.float64)
+    ranks[order] = np.arange(1, len(scores) + 1)
+    # Midranks for ties, so equal scores contribute 0.5 each.
+    for value in np.unique(scores):
+        tied = scores == value
+        if tied.sum() > 1:
+            ranks[tied] = ranks[tied].mean()
+    u_statistic = ranks[labels].sum() - positives * (positives + 1) / 2.0
+    return float(u_statistic / (positives * negatives))
+
+
+def sigmoid(values: np.ndarray | float) -> Any:
+    """Numerically plain sigmoid; raw anomaly scores are small in practice."""
+    return 1.0 / (1.0 + np.exp(-np.asarray(values, dtype=np.float64)))
+
+
+def topk_mean_scores(pixel_scores: np.ndarray, top_k_fraction: float) -> np.ndarray:
+    """Stage-1 image score per frame: mean of the top-k fraction of pixel scores.
+
+    ``k`` replicates the decider bit-for-bit: the product is cast to float32 before ceiling
+    (``TwoStageBinaryDecider.forward``), so calibration and runtime agree even when the
+    float64 product lands epsilon above an integer.
+    """
+    flat = pixel_scores.reshape(pixel_scores.shape[0], -1)
+    k = max(1, int(np.ceil(np.float32(flat.shape[1] * top_k_fraction))))
+    top = np.partition(flat, flat.shape[1] - k, axis=1)[:, -k:]
+    return top.mean(axis=1)
+
+
+def pixel_candidates(pixel_scores: np.ndarray, num_candidates: int) -> np.ndarray:
+    """Absolute-threshold candidates from pooled score quantiles.
+
+    The tail reaches ``1/pixel_scores.size`` (a single pooled pixel) so the achievable
+    precision frontier for sparse anomalies lies inside the grid.
+    """
+    tail_lo = max(1.0 / pixel_scores.size, 1e-12)
+    upper_tail = 1.0 - np.logspace(np.log10(tail_lo), np.log10(0.5), num_candidates)
+    return np.unique(np.quantile(pixel_scores, np.sort(upper_tail)))
+
+
+def quantile_grid_builder(
+    preset_quantile: float, num_candidates: int
+) -> Callable[[int], np.ndarray]:
+    """Quantile-sweep grid deferred on the per-frame pixel count.
+
+    The tail reaches one pixel per frame so the sweep can trade all the way down to a single
+    flagged pixel; the shipped preset value is always included for before/after.
+    """
+
+    def build(numel: int) -> np.ndarray:
+        """Build the quantile grid for frames of ``numel`` score values."""
+        tail_lo = max(1.0 / numel, 1e-12)
+        grid = 1.0 - np.logspace(np.log10(tail_lo), np.log10(0.5), num_candidates)
+        return np.unique(np.append(grid, preset_quantile))
+
+    return build
+
+
+def preset_probe_builder(preset_quantile: float) -> Callable[[int], np.ndarray]:
+    """Single-probe builder: just the shipped preset quantile (before/after reference)."""
+
+    def build(_: int) -> np.ndarray:
+        """Return the preset quantile regardless of frame size."""
+        return np.asarray([preset_quantile])
+
+    return build
+
+
+def sweep_two_stage(
+    pixel_scores: np.ndarray,
+    gt_masks: np.ndarray,
+    image_scores: np.ndarray,
+    frame_labels: np.ndarray,
+    num_candidates: int,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """2-D sweep (image gate x absolute pixel threshold) for ``TwoStageBinaryDecider``.
+
+    Returns ``(best_image, joint_best, conditional_best)``; gated-out frames contribute their
+    full ground truth as misses, which is what couples the two stages.
+    """
+    image_candidates = np.unique(image_scores)
+    image_grid = [
+        {"threshold": float(thr), **image_metrics_at(image_scores, frame_labels, thr)}
+        for thr in image_candidates
+    ]
+    best_image = max(image_grid, key=lambda row: (row["f1"], row["threshold"]))
+
+    candidates = pixel_candidates(pixel_scores, num_candidates)
+    flat_scores = pixel_scores.reshape(len(frame_labels), -1)
+    flat_gt = gt_masks.reshape(len(frame_labels), -1)
+    not_gt = ~flat_gt
+    gt_per_frame = flat_gt.sum(axis=1).astype(np.float64)
+    # Per-frame TP/FP for every pixel candidate: [n_frames, n_candidates]
+    tp = np.empty((len(frame_labels), len(candidates)), dtype=np.float64)
+    fp = np.empty_like(tp)
+    for j, thr in enumerate(candidates):
+        flagged = flat_scores >= thr
+        tp[:, j] = (flagged & flat_gt).sum(axis=1)
+        fp[:, j] = (flagged & not_gt).sum(axis=1)
+
+    total_gt = float(gt_per_frame.sum())
+    joint_best: dict[str, Any] | None = None
+    conditional_best: dict[str, Any] | None = None
+    for image_thr in image_candidates:
+        gate = image_scores >= image_thr
+        gated_tp = tp[gate].sum(axis=0)
+        gated_fp = fp[gate].sum(axis=0)
+        fn = total_gt - gated_tp  # gated-out frames contribute their full GT as misses
+        for j, pixel_thr in enumerate(candidates):
+            row = {
+                "image_threshold": float(image_thr),
+                "pixel_threshold": float(pixel_thr),
+                **prf(float(gated_tp[j]), float(gated_fp[j]), float(fn[j])),
+            }
+            if joint_best is None or row["f1"] > joint_best["f1"]:
+                joint_best = row
+            if image_thr == best_image["threshold"] and (
+                conditional_best is None or row["f1"] > conditional_best["f1"]
+            ):
+                conditional_best = row
+    assert joint_best is not None and conditional_best is not None
+    return best_image, joint_best, conditional_best
+
+
+def sweep_absolute(
+    pixel_scores: np.ndarray, gt_masks: np.ndarray, num_candidates: int
+) -> dict[str, Any]:
+    """Single ungated sweep over an absolute elementwise cutoff (``BinaryDecider``)."""
+    total_gt = float(gt_masks.sum())
+    not_gt = ~gt_masks
+    best: dict[str, Any] | None = None
+    for thr in pixel_candidates(pixel_scores, num_candidates):
+        flagged = pixel_scores >= thr
+        tp = float((flagged & gt_masks).sum())
+        row = {
+            "raw_threshold": float(thr),
+            **prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
+        }
+        if best is None or row["f1"] > best["f1"]:
+            best = row
+    assert best is not None
+    return best
+
+
+def sweep_quantile(
+    pixel_scores: np.ndarray,
+    gt_masks: np.ndarray,
+    frame_quantiles: dict[float, np.ndarray],
+) -> dict[str, Any]:
+    """Sweep the per-frame adaptive ``quantile`` (``QuantileBinaryDecider``)."""
+    total_gt = float(gt_masks.sum())
+    not_gt = ~gt_masks
+    best: dict[str, Any] | None = None
+    for q in sorted(frame_quantiles):
+        thresholds = frame_quantiles[q][:, None, None]
+        flagged = pixel_scores >= thresholds
+        tp = float((flagged & gt_masks).sum())
+        row = {
+            "quantile": float(q),
+            **prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
+        }
+        if best is None or row["f1"] > best["f1"]:
+            best = row
+    assert best is not None
+    return best

--- a/cuvis_ai/node/deciders/binary_decider.py
+++ b/cuvis_ai/node/deciders/binary_decider.py
@@ -139,19 +139,29 @@ class BinaryDecider(BaseDecider):
         """Refit ``threshold`` to F1-max on labelled validation scores.
 
         ``scores`` is the decider-input tensor stacked over the split (``[N, H, W, C]``);
-        ``targets`` the matching ground-truth mask. Sweeps an absolute cutoff in raw score
-        space, maps the optimum through sigmoid (the space this node thresholds), and writes
-        it to both the fitted buffer (``.pt``) and ``hparams`` (yaml). Returns a report.
+        ``targets`` the matching ground-truth mask. The sweep runs on ``torch.sigmoid(scores)``
+        in float32, exactly what ``forward`` compares against ``threshold``, so the fitted
+        value is reachable at runtime even when raw logits saturate the sigmoid. The optimum
+        is moved to the midpoint of its F1 plateau (``_calibration.margin_below``) and written
+        to the live attribute and to ``hparams``; ``pipeline.save_to_file`` then carries it in
+        the pipeline yaml. The ``.pt`` weights are unchanged, so load the saved yaml rather
+        than the preset plus weights. Multi-channel input is reduced to the per-pixel max, which
+        matches ``forward`` exactly for single-channel scores. Returns a report.
+
+        Raises:
+            CalibrationError: shape mismatch, non-finite scores, or a single-class split.
         """
-        _, pixel, gt, _ = _calibration.reduce_scores_targets(scores, targets)
+        probabilities = torch.sigmoid(scores.detach().to("cpu", torch.float32))
+        _, pixel, gt, _ = _calibration.reduce_scores_targets(probabilities, targets)
         best = _calibration.sweep_absolute(pixel, gt, num_candidates)
         old = self.threshold
-        new = float(_calibration.sigmoid(best["raw_threshold"]))
+        new = float(best["margin_threshold"])
         self.threshold = new
         self.hparams["threshold"] = new
         return {
             "class": type(self).__name__,
             "threshold": {"old": old, "new": new},
+            "on_point_threshold": best["threshold"],
             "f1": best["f1"],
             "precision": best["precision"],
             "recall": best["recall"],
@@ -296,9 +306,29 @@ class QuantileBinaryDecider(BaseDecider):
 
         The node recomputes its cutoff from each frame's own scores, so there is no absolute
         threshold to fit - the sweep finds the F1-best flagged-pixel fraction instead (per
-        frame, over the full ``[H, W, C]`` tensor, matching the runtime ``torch.quantile``).
-        Writes the result to the fitted buffer (``.pt``) and ``hparams`` (yaml).
+        frame, over the full ``[H, W, C]`` tensor, matching the runtime ``torch.quantile``
+        with the default ``reduce_dims``). The result is written to the live attribute and to
+        ``hparams``; ``pipeline.save_to_file`` then carries it in the pipeline yaml (the ``.pt``
+        weights are unchanged). Decisions are scored on the per-pixel max over channels, which
+        matches ``forward`` exactly for single-channel scores.
+
+        Raises:
+            CalibrationError: shape mismatch, non-finite scores, a single-class split, or a
+                ``reduce_dims`` that keeps a real (size > 1) non-batch axis out of the quantile,
+                a decision rule the per-frame sweep cannot reproduce.
         """
+        kept = [
+            dim
+            for dim in range(1, scores.dim())
+            if dim not in resolve_reduce_dims(self.reduce_dims, scores.dim())
+            and scores.shape[dim] > 1
+        ]
+        if kept:
+            raise _calibration.CalibrationError(
+                f"{type(self).__name__} reduce_dims={self.reduce_dims!r} keeps axes {kept} of "
+                f"shape {tuple(scores.shape)} out of the quantile; calibration sweeps one "
+                "quantile per frame over all non-batch dims and cannot reproduce that rule"
+            )
         full, pixel, gt, _ = _calibration.reduce_scores_targets(scores, targets)
         flat = full.reshape(full.shape[0], -1)  # [N, H*W*C] - the runtime quantile space
         grid = _calibration.quantile_grid_builder(self.quantile, num_candidates)(flat.shape[1])

--- a/cuvis_ai/node/deciders/binary_decider.py
+++ b/cuvis_ai/node/deciders/binary_decider.py
@@ -13,12 +13,15 @@ convert detector outputs into actionable binary masks for visualization or evalu
 from collections.abc import Sequence
 from typing import Any
 
+import numpy as np
 import torch
 from cuvis_ai_schemas.enums import NodeCategory, NodeTag
 from cuvis_ai_schemas.pipeline import PortSpec
 from torch import Tensor
 
 from cuvis_ai_core.deciders.base_decider import BinaryDecider as BaseDecider
+
+from . import _calibration
 
 
 def resolve_reduce_dims(reduce_dims: tuple[int, ...] | None, tensor_ndim: int) -> tuple[int, ...]:
@@ -129,6 +132,30 @@ class BinaryDecider(BaseDecider):
         # Apply threshold to get binary decisions
         decisions = tensor >= self.threshold
         return {"decisions": decisions}
+
+    def calibrate(
+        self, scores: Tensor, targets: Tensor, *, num_candidates: int = 256
+    ) -> dict[str, Any]:
+        """Refit ``threshold`` to F1-max on labelled validation scores.
+
+        ``scores`` is the decider-input tensor stacked over the split (``[N, H, W, C]``);
+        ``targets`` the matching ground-truth mask. Sweeps an absolute cutoff in raw score
+        space, maps the optimum through sigmoid (the space this node thresholds), and writes
+        it to both the fitted buffer (``.pt``) and ``hparams`` (yaml). Returns a report.
+        """
+        _, pixel, gt, _ = _calibration.reduce_scores_targets(scores, targets)
+        best = _calibration.sweep_absolute(pixel, gt, num_candidates)
+        old = self.threshold
+        new = float(_calibration.sigmoid(best["raw_threshold"]))
+        self.threshold = new
+        self.hparams["threshold"] = new
+        return {
+            "class": type(self).__name__,
+            "threshold": {"old": old, "new": new},
+            "f1": best["f1"],
+            "precision": best["precision"],
+            "recall": best["recall"],
+        }
 
 
 class QuantileBinaryDecider(BaseDecider):
@@ -261,6 +288,34 @@ class QuantileBinaryDecider(BaseDecider):
 
         decisions = (tensor >= threshold).to(torch.bool)
         return {"decisions": decisions}
+
+    def calibrate(
+        self, scores: Tensor, targets: Tensor, *, num_candidates: int = 256
+    ) -> dict[str, Any]:
+        """Refit ``quantile`` to F1-max on labelled validation scores.
+
+        The node recomputes its cutoff from each frame's own scores, so there is no absolute
+        threshold to fit - the sweep finds the F1-best flagged-pixel fraction instead (per
+        frame, over the full ``[H, W, C]`` tensor, matching the runtime ``torch.quantile``).
+        Writes the result to the fitted buffer (``.pt``) and ``hparams`` (yaml).
+        """
+        full, pixel, gt, _ = _calibration.reduce_scores_targets(scores, targets)
+        flat = full.reshape(full.shape[0], -1)  # [N, H*W*C] - the runtime quantile space
+        grid = _calibration.quantile_grid_builder(self.quantile, num_candidates)(flat.shape[1])
+        per_frame = np.quantile(flat, grid, axis=1)  # [len(grid), N]
+        frame_quantiles = {float(q): per_frame[i] for i, q in enumerate(grid)}
+        best = _calibration.sweep_quantile(pixel, gt, frame_quantiles)
+        old = self.quantile
+        new = float(best["quantile"])
+        self.quantile = new
+        self.hparams["quantile"] = new
+        return {
+            "class": type(self).__name__,
+            "quantile": {"old": old, "new": new},
+            "f1": best["f1"],
+            "precision": best["precision"],
+            "recall": best["recall"],
+        }
 
     @staticmethod
     def _validate_quantile(quantile: float) -> None:

--- a/cuvis_ai/node/deciders/two_stage_decider.py
+++ b/cuvis_ai/node/deciders/two_stage_decider.py
@@ -50,13 +50,14 @@ class TwoStageBinaryDecider(BaseDecider):
     Stage 1 is the image gate: the mean of the top ``top_k_fraction`` per-pixel scores must
     reach ``image_threshold`` or the frame gets a blank mask. ``image_threshold=None`` (the
     default) turns the gate off, so every frame reaches stage 2; a training preset ships it
-    as ``null`` and the operator sets the calibrated value at deployment.
+    as ``null`` and :meth:`calibrate` (the in-training calibration phase, or the
+    ``calibrate-thresholds`` CLI) fills in the value fitted on the labelled validation split.
 
     Stage 2 uses the calibrated absolute ``pixel_threshold`` (raw score space) when one is
-    set - e.g. from the ``calibrate-thresholds`` CLI - and otherwise falls back to the
-    per-frame ``quantile`` cutoff, which flags a fixed fraction of every gated frame. With
-    both ``image_threshold`` and ``pixel_threshold`` unset this node is
-    ``QuantileBinaryDecider`` for ``[B, H, W, 1]`` input, decision for decision.
+    set and otherwise falls back to the per-frame ``quantile`` cutoff, which flags a fixed
+    fraction of every gated frame. With both ``image_threshold`` and ``pixel_threshold``
+    unset this node is ``QuantileBinaryDecider`` for ``[B, H, W, 1]`` input, decision for
+    decision.
     """
 
     _category = NodeCategory.TRANSFORM
@@ -145,18 +146,11 @@ class TwoStageBinaryDecider(BaseDecider):
             scores = tensor[b]  # [H, W, C] or [H, W]
             pixel_scores = scores.max(dim=-1)[0] if scores.dim() == 3 else scores
 
-            # Stage 1: image-level gate, skipped entirely when no threshold is set.
+            # Stage 1: image-level gate, skipped entirely when no threshold is set. The
+            # statistic is shared with calibrate(), so a calibrated gate is exact here.
             if self.image_threshold is not None:
-                flat = pixel_scores.reshape(-1)
-                k = max(
-                    1,
-                    int(
-                        torch.ceil(
-                            torch.tensor(flat.numel() * self.top_k_fraction, dtype=torch.float32)
-                        ).item()
-                    ),
-                )
-                image_score = torch.topk(flat, k).values.mean().item()
+                k = _calibration.topk_count(pixel_scores.numel(), self.top_k_fraction)
+                image_score = _calibration.frame_image_score(pixel_scores, self.top_k_fraction)
                 # Lazy args (bound as defaults so each frame logs its own values): nothing
                 # is formatted unless the debug level is enabled.
                 if image_score < self.image_threshold:
@@ -206,18 +200,27 @@ class TwoStageBinaryDecider(BaseDecider):
         Runs the joint 2-D sweep (image gate x absolute pixel cutoff, raw score space, with
         gated-out frames contributing their full ground truth as misses). Sets the F1-max
         image gate and, at that gate, the F1-max absolute pixel threshold - moving stage 2
-        off the fixed-fraction quantile onto a cutoff that tracks anomaly size. Writes both
-        to fitted buffers (``.pt``) and ``hparams`` (yaml). ``scores`` is the decider-input
-        tensor stacked over the split (``[N, H, W, C]``); ``targets`` the ground-truth mask.
+        off the fixed-fraction quantile onto a cutoff that tracks anomaly size. Both values
+        are the midpoints of their F1 plateaus (``_calibration.margin_below``); the pixel
+        cutoff is exact in float32, the dtype ``forward`` compares in, and the gate uses the
+        very ``frame_image_score`` statistic ``forward`` computes. The values go to the live
+        attributes and to ``hparams``; ``pipeline.save_to_file`` then carries them in the
+        pipeline yaml. The ``.pt`` weights are unchanged, so load the saved yaml rather than
+        the preset plus weights. ``scores`` is the decider-input tensor stacked over the split
+        (``[N, H, W, C]``); ``targets`` the ground-truth mask. The report also carries the
+        on-point optima and the joint optimum, which may beat the conditional one.
+
+        Raises:
+            CalibrationError: shape mismatch, non-finite scores, or a single-class split.
         """
         _, pixel, gt, frame_labels = _calibration.reduce_scores_targets(scores, targets)
         image_scores = _calibration.topk_mean_scores(pixel, self.top_k_fraction)
-        best_image, _joint, conditional = _calibration.sweep_two_stage(
+        best_image, joint, conditional = _calibration.sweep_two_stage(
             pixel, gt, image_scores, frame_labels, num_candidates
         )
         old_image, old_pixel = self.image_threshold, self.pixel_threshold
-        new_image = float(best_image["threshold"])
-        new_pixel = float(conditional["pixel_threshold"])
+        new_image = float(best_image["margin_threshold"])
+        new_pixel = float(conditional["margin_pixel_threshold"])
         self.image_threshold = new_image
         self.pixel_threshold = new_pixel
         self.hparams["image_threshold"] = new_image
@@ -226,9 +229,18 @@ class TwoStageBinaryDecider(BaseDecider):
             "class": type(self).__name__,
             "image_threshold": {"old": old_image, "new": new_image},
             "pixel_threshold": {"old": old_pixel, "new": new_pixel},
+            "on_point": {
+                "image_threshold": best_image["threshold"],
+                "pixel_threshold": conditional["pixel_threshold"],
+            },
             "image_f1": best_image["f1"],
             "pixel_f1": conditional["f1"],
             "pixel_precision": conditional["precision"],
             "pixel_recall": conditional["recall"],
             "pixel_iou": conditional["iou"],
+            "joint": {
+                "image_threshold": joint["margin_image_threshold"],
+                "pixel_threshold": joint["margin_pixel_threshold"],
+                "f1": joint["f1"],
+            },
         }

--- a/cuvis_ai/node/deciders/two_stage_decider.py
+++ b/cuvis_ai/node/deciders/two_stage_decider.py
@@ -28,6 +28,8 @@ from torch import Tensor
 
 from cuvis_ai_core.deciders.base_decider import BinaryDecider as BaseDecider
 
+from . import _calibration
+
 
 def _optional_finite(name: str, value: Any) -> float | None:
     """Return ``value`` as a float, pass ``None`` through, refuse anything else by name.
@@ -195,3 +197,38 @@ class TwoStageBinaryDecider(BaseDecider):
             decisions.append((pixel_scores >= threshold).unsqueeze(-1).to(torch.bool))
 
         return {"decisions": torch.stack(decisions, dim=0)}
+
+    def calibrate(
+        self, scores: Tensor, targets: Tensor, *, num_candidates: int = 256
+    ) -> dict[str, Any]:
+        """Refit ``image_threshold`` + ``pixel_threshold`` to F1-max on labelled val scores.
+
+        Runs the joint 2-D sweep (image gate x absolute pixel cutoff, raw score space, with
+        gated-out frames contributing their full ground truth as misses). Sets the F1-max
+        image gate and, at that gate, the F1-max absolute pixel threshold - moving stage 2
+        off the fixed-fraction quantile onto a cutoff that tracks anomaly size. Writes both
+        to fitted buffers (``.pt``) and ``hparams`` (yaml). ``scores`` is the decider-input
+        tensor stacked over the split (``[N, H, W, C]``); ``targets`` the ground-truth mask.
+        """
+        _, pixel, gt, frame_labels = _calibration.reduce_scores_targets(scores, targets)
+        image_scores = _calibration.topk_mean_scores(pixel, self.top_k_fraction)
+        best_image, _joint, conditional = _calibration.sweep_two_stage(
+            pixel, gt, image_scores, frame_labels, num_candidates
+        )
+        old_image, old_pixel = self.image_threshold, self.pixel_threshold
+        new_image = float(best_image["threshold"])
+        new_pixel = float(conditional["pixel_threshold"])
+        self.image_threshold = new_image
+        self.pixel_threshold = new_pixel
+        self.hparams["image_threshold"] = new_image
+        self.hparams["pixel_threshold"] = new_pixel
+        return {
+            "class": type(self).__name__,
+            "image_threshold": {"old": old_image, "new": new_image},
+            "pixel_threshold": {"old": old_pixel, "new": new_pixel},
+            "image_f1": best_image["f1"],
+            "pixel_f1": conditional["f1"],
+            "pixel_precision": conditional["precision"],
+            "pixel_recall": conditional["recall"],
+            "pixel_iou": conditional["iou"],
+        }

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -597,29 +597,28 @@ def calibrate_thresholds(
                     "conditional_on_image_f1max": conditional_best,
                 },
                 "current_preset": current,
-                "calibrated_decider_hparams": {
-                    "image_threshold": float(best_image["threshold"]),
-                    "top_k_fraction": top_k_fraction,
-                    "pixel_threshold": float(conditional_best["pixel_threshold"]),
-                },
+                "calibrated_decider_hparams": _two_stage_hparams(
+                    best_image, conditional_best, top_k_fraction
+                ),
             }
         )
     elif mode == "binary":
         frame_max = pixel_scores.max(axis=(1, 2))
-        best = _calib.sweep_absolute(pixel_scores, gt_masks, num_candidates)
-        current = _current_preset_binary(pixel_scores, gt_masks, decider_defaults)
+        # BinaryDecider.forward compares float32 sigmoid probabilities, so the sweep runs on
+        # exactly those values (the same torch op) instead of raw scores mapped afterwards.
+        probabilities = _calib.sigmoid_float32(pixel_scores)
+        best = _calib.sweep_absolute(probabilities, gt_masks, num_candidates)
+        current = _current_preset_binary(probabilities, gt_masks, decider_defaults)
         report.update(
             {
                 "score_space": (
-                    "sigmoid probability (BinaryDecider thresholds sigmoid(logits); the "
-                    "sweep ran in raw space and the optimum was mapped through sigmoid)"
+                    "float32 sigmoid probability (the space BinaryDecider.forward compares "
+                    "in; the sweep ran on these probabilities directly)"
                 ),
                 "frame_auroc_max_score": _calib.binary_auroc(frame_max, frame_labels),
                 "pixel": {"optimum": best},
                 "current_preset": current,
-                "calibrated_decider_hparams": {
-                    "threshold": float(_calib.sigmoid(best["raw_threshold"]))
-                },
+                "calibrated_decider_hparams": _binary_hparams(best),
             }
         )
     else:  # quantile
@@ -693,12 +692,35 @@ def _current_preset_two_stage(
     }
 
 
+def _two_stage_hparams(
+    best_image: dict[str, Any], conditional_best: dict[str, Any], top_k_fraction: float
+) -> dict[str, float]:
+    """The ``TwoStageBinaryDecider`` hparams to ship: the plateau-midpoint values.
+
+    Identical to what ``TwoStageBinaryDecider.calibrate`` writes for the same scores.
+    """
+    return {
+        "image_threshold": float(best_image["margin_threshold"]),
+        "top_k_fraction": top_k_fraction,
+        "pixel_threshold": float(conditional_best["margin_pixel_threshold"]),
+    }
+
+
+def _binary_hparams(best: dict[str, Any]) -> dict[str, float]:
+    """The ``BinaryDecider`` hparams to ship (float32 sigmoid space, plateau midpoint)."""
+    return {"threshold": float(best["margin_threshold"])}
+
+
 def _current_preset_binary(
-    pixel_scores: np.ndarray, gt_masks: np.ndarray, decider_defaults: dict[str, Any]
+    probabilities: np.ndarray, gt_masks: np.ndarray, decider_defaults: dict[str, Any]
 ) -> dict[str, Any]:
-    """Metrics at the ``BinaryDecider`` sigmoid-space threshold currently shipped."""
+    """Metrics at the ``BinaryDecider`` threshold currently shipped.
+
+    ``probabilities`` are the float32 sigmoid values ``forward`` compares (see
+    ``_calibration.sigmoid_float32``), so this is the decision ``forward`` makes today.
+    """
     threshold = float(decider_defaults.get("threshold", 0.5))
-    flagged = _calib.sigmoid(pixel_scores) >= threshold
+    flagged = probabilities >= threshold
     tp = float((flagged & gt_masks).sum())
     fp = float((flagged & ~gt_masks).sum())
     fn = float(gt_masks.sum()) - tp
@@ -774,7 +796,7 @@ def _print_report(report: dict[str, Any]) -> None:
         print(  # noqa: T201
             f"frame AUROC (max pixel score, informational): {report['frame_auroc_max_score']:.4f}"
         )
-        knob = "quantile" if mode == "quantile" else "raw_threshold"
+        knob = "quantile" if mode == "quantile" else "threshold"
         print(  # noqa: T201
             f"pixel F1 optimum: {best['f1']:.4f} at {knob}={best[knob]:.6f} "
             f"(P={best['precision']:.3f} R={best['recall']:.3f} IoU={best['iou']:.3f})"

--- a/scripts/calibrate_thresholds.py
+++ b/scripts/calibrate_thresholds.py
@@ -68,6 +68,7 @@ from cuvis_ai_schemas.execution import Context
 from cuvis_ai_schemas.pipeline import PipelineConfig
 from loguru import logger
 
+from cuvis_ai.node.deciders import _calibration as _calib
 from cuvis_ai.utils.grpc_workflow import CONFIG_ROOT
 from cuvis_ai_core.pipeline.pipeline import CuvisPipeline
 from cuvis_ai_core.training.config import TrainRunConfig
@@ -438,196 +439,6 @@ def _single_port(
     return next(iter(hits.values()))
 
 
-def _topk_mean_scores(pixel_scores: np.ndarray, top_k_fraction: float) -> np.ndarray:
-    """Stage-1 image score per frame: mean of the top-k fraction of pixel scores.
-
-    ``k`` replicates the decider bit-for-bit: the product is cast to float32 before
-    ceiling (two_stage_decider.forward), so calibration and runtime agree even when the
-    float64 product lands epsilon above an integer.
-    """
-    flat = pixel_scores.reshape(pixel_scores.shape[0], -1)
-    k = max(1, int(np.ceil(np.float32(flat.shape[1] * top_k_fraction))))
-    top = np.partition(flat, flat.shape[1] - k, axis=1)[:, -k:]
-    return top.mean(axis=1)
-
-
-def _binary_auroc(scores: np.ndarray, labels: np.ndarray) -> float:
-    """Exact rank-based AUROC (Mann-Whitney U) for a small sample count."""
-    positives = int(labels.sum())
-    negatives = int((~labels).sum())
-    if positives == 0 or negatives == 0:
-        return float("nan")
-    order = scores.argsort(kind="mergesort")
-    ranks = np.empty_like(order, dtype=np.float64)
-    ranks[order] = np.arange(1, len(scores) + 1)
-    # Midranks for ties, so equal scores contribute 0.5 each.
-    for value in np.unique(scores):
-        tied = scores == value
-        if tied.sum() > 1:
-            ranks[tied] = ranks[tied].mean()
-    u_statistic = ranks[labels].sum() - positives * (positives + 1) / 2.0
-    return float(u_statistic / (positives * negatives))
-
-
-def _prf(tp: float, fp: float, fn: float) -> dict[str, float]:
-    """Precision, recall, F1 and IoU from raw counts (0 when undefined)."""
-    precision = tp / (tp + fp) if tp + fp > 0 else 0.0
-    recall = tp / (tp + fn) if tp + fn > 0 else 0.0
-    f1 = 2 * precision * recall / (precision + recall) if precision + recall > 0 else 0.0
-    iou = tp / (tp + fp + fn) if tp + fp + fn > 0 else 0.0
-    return {"precision": precision, "recall": recall, "f1": f1, "iou": iou}
-
-
-def _image_metrics_at(image_scores: np.ndarray, labels: np.ndarray, thr: float) -> dict[str, float]:
-    """Frame-level precision/recall/F1/IoU at one image threshold (``>=``)."""
-    flagged = image_scores >= thr
-    tp = float((flagged & labels).sum())
-    return _prf(tp, float((flagged & ~labels).sum()), float((~flagged & labels).sum()))
-
-
-def _pixel_candidates(pixel_scores: np.ndarray, num_candidates: int) -> np.ndarray:
-    """Absolute-threshold candidates from pooled score quantiles.
-
-    The tail reaches ``1/pixel_scores.size`` (a single pooled pixel) so the achievable
-    precision frontier for sparse anomalies lies inside the grid.
-    """
-    tail_lo = max(1.0 / pixel_scores.size, 1e-12)
-    upper_tail = 1.0 - np.logspace(np.log10(tail_lo), np.log10(0.5), num_candidates)
-    return np.unique(np.quantile(pixel_scores, np.sort(upper_tail)))
-
-
-def _sweep_two_stage(
-    pixel_scores: np.ndarray,
-    gt_masks: np.ndarray,
-    image_scores: np.ndarray,
-    frame_labels: np.ndarray,
-    num_candidates: int,
-) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """2-D sweep (image gate x absolute pixel threshold) for ``TwoStageBinaryDecider``.
-
-    Returns ``(best_image, joint_best, conditional_best)``; gated-out frames contribute
-    their full ground truth as misses, which is what couples the two stages.
-    """
-    image_candidates = np.unique(image_scores)
-    image_grid = [
-        {"threshold": float(thr), **_image_metrics_at(image_scores, frame_labels, thr)}
-        for thr in image_candidates
-    ]
-    best_image = max(image_grid, key=lambda row: (row["f1"], row["threshold"]))
-
-    pixel_candidates = _pixel_candidates(pixel_scores, num_candidates)
-    flat_scores = pixel_scores.reshape(len(frame_labels), -1)
-    flat_gt = gt_masks.reshape(len(frame_labels), -1)
-    not_gt = ~flat_gt
-    gt_per_frame = flat_gt.sum(axis=1).astype(np.float64)
-    # Per-frame TP/FP for every pixel candidate: [n_frames, n_candidates]
-    tp = np.empty((len(frame_labels), len(pixel_candidates)), dtype=np.float64)
-    fp = np.empty_like(tp)
-    for j, thr in enumerate(pixel_candidates):
-        flagged = flat_scores >= thr
-        tp[:, j] = (flagged & flat_gt).sum(axis=1)
-        fp[:, j] = (flagged & not_gt).sum(axis=1)
-
-    total_gt = float(gt_per_frame.sum())
-    joint_best: dict[str, Any] | None = None
-    conditional_best: dict[str, Any] | None = None
-    for image_thr in image_candidates:
-        gate = image_scores >= image_thr
-        gated_tp = tp[gate].sum(axis=0)
-        gated_fp = fp[gate].sum(axis=0)
-        fn = total_gt - gated_tp  # gated-out frames contribute their full GT as misses
-        for j, pixel_thr in enumerate(pixel_candidates):
-            row = {
-                "image_threshold": float(image_thr),
-                "pixel_threshold": float(pixel_thr),
-                **_prf(float(gated_tp[j]), float(gated_fp[j]), float(fn[j])),
-            }
-            if joint_best is None or row["f1"] > joint_best["f1"]:
-                joint_best = row
-            if image_thr == best_image["threshold"] and (
-                conditional_best is None or row["f1"] > conditional_best["f1"]
-            ):
-                conditional_best = row
-    assert joint_best is not None and conditional_best is not None
-    return best_image, joint_best, conditional_best
-
-
-def _sweep_absolute(
-    pixel_scores: np.ndarray, gt_masks: np.ndarray, num_candidates: int
-) -> dict[str, Any]:
-    """Single ungated sweep over an absolute elementwise cutoff (``BinaryDecider``)."""
-    total_gt = float(gt_masks.sum())
-    not_gt = ~gt_masks
-    best: dict[str, Any] | None = None
-    for thr in _pixel_candidates(pixel_scores, num_candidates):
-        flagged = pixel_scores >= thr
-        tp = float((flagged & gt_masks).sum())
-        row = {
-            "raw_threshold": float(thr),
-            **_prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
-        }
-        if best is None or row["f1"] > best["f1"]:
-            best = row
-    assert best is not None
-    return best
-
-
-def _sweep_quantile(
-    pixel_scores: np.ndarray,
-    gt_masks: np.ndarray,
-    frame_quantiles: dict[float, np.ndarray],
-) -> dict[str, Any]:
-    """Sweep the per-frame adaptive ``quantile`` (``QuantileBinaryDecider``)."""
-    total_gt = float(gt_masks.sum())
-    not_gt = ~gt_masks
-    best: dict[str, Any] | None = None
-    for q in sorted(frame_quantiles):
-        thresholds = frame_quantiles[q][:, None, None]
-        flagged = pixel_scores >= thresholds
-        tp = float((flagged & gt_masks).sum())
-        row = {
-            "quantile": float(q),
-            **_prf(tp, float((flagged & not_gt).sum()), total_gt - tp),
-        }
-        if best is None or row["f1"] > best["f1"]:
-            best = row
-    assert best is not None
-    return best
-
-
-def _sigmoid(values: np.ndarray | float) -> Any:
-    """Numerically plain sigmoid; raw anomaly scores are small in practice."""
-    return 1.0 / (1.0 + np.exp(-np.asarray(values, dtype=np.float64)))
-
-
-def _quantile_grid_builder(
-    preset_quantile: float, num_candidates: int
-) -> Callable[[int], np.ndarray]:
-    """Quantile-sweep grid deferred on the per-frame pixel count.
-
-    The tail reaches one pixel per frame so the sweep can trade all the way down to a
-    single flagged pixel; the shipped preset value is always included for before/after.
-    """
-
-    def build(numel: int) -> np.ndarray:
-        """Build the quantile grid for frames of ``numel`` score values."""
-        tail_lo = max(1.0 / numel, 1e-12)
-        grid = 1.0 - np.logspace(np.log10(tail_lo), np.log10(0.5), num_candidates)
-        return np.unique(np.append(grid, preset_quantile))
-
-    return build
-
-
-def _preset_probe_builder(preset_quantile: float) -> Callable[[int], np.ndarray]:
-    """Single-probe builder: just the shipped preset quantile (before/after reference)."""
-
-    def build(_: int) -> np.ndarray:
-        """Return the preset quantile regardless of frame size."""
-        return np.asarray([preset_quantile])
-
-    return build
-
-
 def _warn_history_dependent(config: PipelineConfig) -> list[str]:
     """Warn about nodes whose score distribution depends on frame order / warm-up."""
     flagged = []
@@ -728,9 +539,9 @@ def calibrate_thresholds(
     preset_quantile = float(decider_defaults.get("quantile", 0.995))
     probe_builder: Callable[[int], np.ndarray] | None = None
     if mode == "quantile":
-        probe_builder = _quantile_grid_builder(preset_quantile, num_candidates)
+        probe_builder = _calib.quantile_grid_builder(preset_quantile, num_candidates)
     elif mode == "two_stage" and decider_defaults.get("pixel_threshold") is None:
-        probe_builder = _preset_probe_builder(preset_quantile)
+        probe_builder = _calib.preset_probe_builder(preset_quantile)
 
     pipeline = _build_pipeline(resolved_yaml, resolved_weights, device, plugins_dirs)
     candidate_dirs = _plugins_candidates(resolved_trainrun, plugins_dirs)
@@ -766,8 +577,8 @@ def calibrate_thresholds(
     }
 
     if mode == "two_stage":
-        image_scores = _topk_mean_scores(pixel_scores, top_k_fraction)
-        best_image, joint_best, conditional_best = _sweep_two_stage(
+        image_scores = _calib.topk_mean_scores(pixel_scores, top_k_fraction)
+        best_image, joint_best, conditional_best = _calib.sweep_two_stage(
             pixel_scores, gt_masks, image_scores, frame_labels, num_candidates
         )
         current = _current_preset_two_stage(
@@ -778,7 +589,7 @@ def calibrate_thresholds(
                 "top_k_fraction": top_k_fraction,
                 "score_space": "raw (no sigmoid; the space TwoStageBinaryDecider thresholds in)",
                 "image": {
-                    "auroc": _binary_auroc(image_scores, frame_labels),
+                    "auroc": _calib.binary_auroc(image_scores, frame_labels),
                     "f1_max": best_image,
                 },
                 "pixel": {
@@ -795,7 +606,7 @@ def calibrate_thresholds(
         )
     elif mode == "binary":
         frame_max = pixel_scores.max(axis=(1, 2))
-        best = _sweep_absolute(pixel_scores, gt_masks, num_candidates)
+        best = _calib.sweep_absolute(pixel_scores, gt_masks, num_candidates)
         current = _current_preset_binary(pixel_scores, gt_masks, decider_defaults)
         report.update(
             {
@@ -803,15 +614,17 @@ def calibrate_thresholds(
                     "sigmoid probability (BinaryDecider thresholds sigmoid(logits); the "
                     "sweep ran in raw space and the optimum was mapped through sigmoid)"
                 ),
-                "frame_auroc_max_score": _binary_auroc(frame_max, frame_labels),
+                "frame_auroc_max_score": _calib.binary_auroc(frame_max, frame_labels),
                 "pixel": {"optimum": best},
                 "current_preset": current,
-                "calibrated_decider_hparams": {"threshold": float(_sigmoid(best["raw_threshold"]))},
+                "calibrated_decider_hparams": {
+                    "threshold": float(_calib.sigmoid(best["raw_threshold"]))
+                },
             }
         )
     else:  # quantile
         frame_max = pixel_scores.max(axis=(1, 2))
-        best = _sweep_quantile(pixel_scores, gt_masks, frame_quantiles)
+        best = _calib.sweep_quantile(pixel_scores, gt_masks, frame_quantiles)
         current = _current_preset_quantile(pixel_scores, gt_masks, preset_quantile, frame_quantiles)
         report.update(
             {
@@ -820,7 +633,7 @@ def calibrate_thresholds(
                     "each frame's own scores; no absolute threshold exists to calibrate - "
                     "the swept quantile fixes the flagged-pixel fraction per frame)"
                 ),
-                "frame_auroc_max_score": _binary_auroc(frame_max, frame_labels),
+                "frame_auroc_max_score": _calib.binary_auroc(frame_max, frame_labels),
                 "pixel": {"optimum": best},
                 "current_preset": current,
                 "calibrated_decider_hparams": {"quantile": float(best["quantile"])},
@@ -872,11 +685,11 @@ def _current_preset_two_stage(
         "image_threshold": image_thr,
         "stage2": stage2,
         "image": (
-            _image_metrics_at(image_scores, frame_labels, image_thr)
+            _calib.image_metrics_at(image_scores, frame_labels, image_thr)
             if image_thr is not None
             else None
         ),
-        "pixel": _prf(tp, fp, fn),
+        "pixel": _calib.prf(tp, fp, fn),
     }
 
 
@@ -885,11 +698,11 @@ def _current_preset_binary(
 ) -> dict[str, Any]:
     """Metrics at the ``BinaryDecider`` sigmoid-space threshold currently shipped."""
     threshold = float(decider_defaults.get("threshold", 0.5))
-    flagged = _sigmoid(pixel_scores) >= threshold
+    flagged = _calib.sigmoid(pixel_scores) >= threshold
     tp = float((flagged & gt_masks).sum())
     fp = float((flagged & ~gt_masks).sum())
     fn = float(gt_masks.sum()) - tp
-    return {"threshold": threshold, "pixel": _prf(tp, fp, fn)}
+    return {"threshold": threshold, "pixel": _calib.prf(tp, fp, fn)}
 
 
 def _current_preset_quantile(
@@ -904,7 +717,7 @@ def _current_preset_quantile(
     tp = float((flagged & gt_masks).sum())
     fp = float((flagged & ~gt_masks).sum())
     fn = float(gt_masks.sum()) - tp
-    return {"quantile": preset_quantile, "pixel": _prf(tp, fp, fn)}
+    return {"quantile": preset_quantile, "pixel": _calib.prf(tp, fp, fn)}
 
 
 def _print_report(report: dict[str, Any]) -> None:

--- a/tests/deciders/test_calibration_sweeps.py
+++ b/tests/deciders/test_calibration_sweeps.py
@@ -1,0 +1,225 @@
+"""Pure-numpy tests for the shared threshold-calibration sweep helpers.
+
+These pin the numerics the deciders and the ``calibrate-thresholds`` CLI both rely on: the
+one-pass ``searchsorted`` confusion counts match the plain per-candidate loop bit for bit,
+candidates and margins are exact in float32 (the dtype the deciders compare pixel scores
+in), the stage-1 image score is the statistic ``TwoStageBinaryDecider.forward`` computes, and
+unusable input is refused with a ``CalibrationError`` that names the problem.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from cuvis_ai.node.deciders import _calibration as calib
+
+pytestmark = pytest.mark.unit
+
+
+def _random_split(seed: int = 0, n: int = 4, size: int = 16, positive_rate: float = 0.05):
+    """Random float32 scores with ties plus a sparse random mask, as numpy arrays."""
+    rng = np.random.default_rng(seed)
+    # Integer-valued scores divided by 10 give plenty of exact ties.
+    pixel = (rng.integers(0, 40, size=(n, size, size)) / 10).astype(np.float32)
+    gt = rng.random((n, size, size)) < positive_rate
+    gt[0, 0, 0] = True  # guarantee at least one positive
+    gt[1, 0, 0] = False  # and one negative
+    return pixel, gt
+
+
+def _reference_confusions(pixel_scores, gt_masks, candidates):
+    """The pre-searchsorted implementation: one full pass per candidate."""
+    n = pixel_scores.shape[0]
+    flat_scores = pixel_scores.reshape(n, -1)
+    flat_gt = gt_masks.reshape(n, -1)
+    tp = np.empty((n, candidates.size), dtype=np.float64)
+    fp = np.empty_like(tp)
+    for j, thr in enumerate(candidates):
+        flagged = flat_scores >= thr
+        tp[:, j] = (flagged & flat_gt).sum(axis=1)
+        fp[:, j] = (flagged & ~flat_gt).sum(axis=1)
+    return tp, fp
+
+
+def _reference_image_score(pixel_scores: torch.Tensor, top_k_fraction: float) -> float:
+    """The stage-1 statistic as it was written inline in ``TwoStageBinaryDecider.forward``."""
+    flat = pixel_scores.reshape(-1)
+    k = max(
+        1,
+        int(torch.ceil(torch.tensor(flat.numel() * top_k_fraction, dtype=torch.float32)).item()),
+    )
+    return torch.topk(flat, k).values.mean().item()
+
+
+# --- margin_below ---------------------------------------------------------------------
+
+
+def test_margin_below_is_the_plateau_midpoint():
+    samples = np.array([0.0, 0.0, 5.0, 5.0], dtype=np.float32)
+    assert calib.margin_below(5.0, samples, float32=True) == 2.5
+    assert calib.margin_below(5.0, samples, float32=False) == 2.5
+
+
+def test_margin_below_without_a_lower_sample_returns_the_threshold():
+    samples = np.array([5.0, 5.0], dtype=np.float32)
+    assert calib.margin_below(5.0, samples, float32=True) == 5.0
+
+
+def test_margin_below_float32_falls_back_when_the_midpoint_collapses():
+    upper = np.float32(1.0)
+    lower = np.nextafter(upper, np.float32(0.0))  # adjacent float32 values
+    samples = np.array([lower, upper], dtype=np.float32)
+    margin = calib.margin_below(float(upper), samples, float32=True)
+    assert margin == float(upper)  # no float32 value fits strictly between the two
+    assert np.float32(margin) == margin
+
+
+# --- candidates and confusions ----------------------------------------------------------
+
+
+def test_pixel_candidates_are_float32_exact_sorted_and_include_the_max():
+    pixel, _ = _random_split()
+    candidates = calib.pixel_candidates(pixel, 64)
+    assert candidates.dtype == np.float32
+    assert np.all(np.diff(candidates) > 0)
+    assert np.float32(pixel.max()) in candidates
+    assert all(np.float32(float(c)) == c for c in candidates)
+
+
+def test_frame_confusions_match_the_per_candidate_loop():
+    for seed in range(3):
+        pixel, gt = _random_split(seed=seed)
+        candidates = calib.pixel_candidates(pixel, 64)
+        tp, fp = calib.frame_confusions(pixel, gt, candidates)
+        ref_tp, ref_fp = _reference_confusions(pixel, gt, candidates)
+        np.testing.assert_array_equal(tp, ref_tp)
+        np.testing.assert_array_equal(fp, ref_fp)
+
+
+def test_sweep_absolute_margin_lies_strictly_between_adjacent_samples():
+    pixel, gt = _random_split(seed=1)
+    best = calib.sweep_absolute(pixel, gt, 64)
+    threshold, margin = best["threshold"], best["margin_threshold"]
+    assert np.float32(threshold) == threshold
+    assert np.float32(margin) == margin
+    below = pixel[pixel < threshold]
+    if below.size:
+        assert float(below.max()) < margin <= threshold
+    else:
+        assert margin == threshold
+    # Same flagged set, so the same F1 as the on-point optimum.
+    flagged = pixel >= np.float32(margin)
+    tp = float((flagged & gt).sum())
+    assert calib.prf(tp, float((flagged & ~gt).sum()), float(gt.sum()) - tp)["f1"] == best["f1"]
+
+
+def test_sweep_two_stage_carries_on_point_and_margin_keys():
+    pixel, gt = _random_split(seed=2)
+    frame_labels = gt.any(axis=(1, 2))
+    image_scores = calib.topk_mean_scores(pixel, 0.01)
+    best_image, joint, conditional = calib.sweep_two_stage(
+        pixel, gt, image_scores, frame_labels, 64
+    )
+    assert {"threshold", "margin_threshold", "f1"} <= best_image.keys()
+    for row in (joint, conditional):
+        assert {"pixel_threshold", "margin_pixel_threshold", "margin_image_threshold"} <= row.keys()
+        assert np.float32(row["margin_pixel_threshold"]) == row["margin_pixel_threshold"]
+    assert conditional["image_threshold"] == best_image["threshold"]
+    assert joint["f1"] >= conditional["f1"]
+
+
+def test_sweep_ties_resolve_to_the_highest_candidate():
+    # Every threshold in (0, 5] separates perfectly: the highest candidate (5.0) must win.
+    pixel = np.zeros((2, 4, 4), dtype=np.float32)
+    gt = np.zeros((2, 4, 4), dtype=bool)
+    pixel[1, :2, :2] = 5.0
+    gt[1, :2, :2] = True
+    best = calib.sweep_absolute(pixel, gt, 32)
+    assert best["threshold"] == 5.0
+    assert best["margin_threshold"] == 2.5
+
+
+# --- stage-1 image score ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("top_k_fraction", [0.001, 0.25, 0.5, 1.0])
+def test_frame_image_score_matches_the_inline_forward_statistic(top_k_fraction):
+    frames = torch.rand(5, 23, 31, generator=torch.Generator().manual_seed(0))
+    for frame in frames:
+        assert calib.frame_image_score(frame, top_k_fraction) == _reference_image_score(
+            frame, top_k_fraction
+        )
+    stacked = calib.topk_mean_scores(frames.numpy(), top_k_fraction)
+    assert stacked.dtype == np.float64
+    assert stacked.tolist() == [_reference_image_score(f, top_k_fraction) for f in frames]
+
+
+def test_topk_count_rounds_the_product_in_float32():
+    # 1000 * 0.001 is 1.0000000000000002 in float64 but exactly 1 in float32: k stays 1.
+    assert calib.topk_count(1000, 0.001) == 1
+    assert calib.topk_count(1, 1e-9) == 1  # never below one pixel
+
+
+# --- sigmoid space ------------------------------------------------------------------------
+
+
+def test_sigmoid_float32_matches_torch_and_saturates():
+    values = np.array([-40.0, 0.0, 5.0, 20.0, 40.0], dtype=np.float32)
+    probs = calib.sigmoid_float32(values)
+    assert probs.dtype == np.float32
+    np.testing.assert_array_equal(probs, torch.sigmoid(torch.from_numpy(values)).numpy())
+    assert probs[3] == 1.0 and probs[4] == 1.0  # float32 saturation above logits of ~17
+
+
+# --- guards --------------------------------------------------------------------------------
+
+
+def _scores_and_targets(n=2, size=4):
+    scores = torch.zeros(n, size, size, 1)
+    targets = torch.zeros(n, size, size, 1, dtype=torch.bool)
+    scores[1, 0, 0, 0] = 5.0
+    targets[1, 0, 0, 0] = True
+    return scores, targets
+
+
+def test_reduce_scores_targets_accepts_3d_and_4d_layouts():
+    scores, targets = _scores_and_targets()
+    full, pixel, gt, frame_labels = calib.reduce_scores_targets(scores, targets[..., 0])
+    assert full.shape == (2, 4, 4, 1) and pixel.shape == (2, 4, 4)
+    assert pixel.dtype == np.float32 and gt.dtype == bool
+    assert frame_labels.tolist() == [False, True]
+
+
+def test_reduce_scores_targets_refuses_shape_mismatch():
+    scores, targets = _scores_and_targets()
+    with pytest.raises(calib.CalibrationError, match=r"disagree on \[N, H, W\]"):
+        calib.reduce_scores_targets(scores, targets[:1])
+    with pytest.raises(calib.CalibrationError, match="scores must be"):
+        calib.reduce_scores_targets(scores[0, 0], targets[0, 0])  # rank 2: not a frame stack
+
+
+def test_reduce_scores_targets_refuses_non_finite_scores():
+    scores, targets = _scores_and_targets()
+    scores[0, 1, 1, 0] = float("nan")
+    with pytest.raises(calib.CalibrationError, match="nan or inf"):
+        calib.reduce_scores_targets(scores, targets)
+
+
+def test_reduce_scores_targets_refuses_single_class_targets():
+    scores, targets = _scores_and_targets()
+    with pytest.raises(calib.CalibrationError, match="no anomalous pixel"):
+        calib.reduce_scores_targets(scores, torch.zeros_like(targets))
+    with pytest.raises(calib.CalibrationError, match="every pixel anomalous"):
+        calib.reduce_scores_targets(scores, torch.ones_like(targets))
+
+
+# --- auroc ---------------------------------------------------------------------------------
+
+
+def test_binary_auroc_separable_ties_and_single_class():
+    labels = np.array([False, False, True, True])
+    assert calib.binary_auroc(np.array([0.1, 0.2, 0.8, 0.9]), labels) == 1.0
+    assert calib.binary_auroc(np.array([0.5, 0.5, 0.5, 0.5]), labels) == 0.5  # midranks
+    assert np.isnan(calib.binary_auroc(np.array([0.1, 0.9]), np.array([True, True])))

--- a/tests/deciders/test_decider_calibration.py
+++ b/tests/deciders/test_decider_calibration.py
@@ -1,0 +1,108 @@
+"""Calibration of the binary deciders against a labelled split.
+
+Each ``calibrate(scores, targets)`` re-fits the decider's own decision rule to F1-max on
+labelled validation scores and writes the result to both the live attribute (so ``forward``
+uses it) and ``hparams`` (so it serialises into the pipeline yaml). The golden tests build a
+cleanly separable synthetic split, calibrate, and assert the recalibrated decider reproduces
+the ground truth in ``forward`` - the end-to-end contract - plus the live/hparam/report
+consistency that makes the value persist.
+"""
+
+import pytest
+import torch
+
+from cuvis_ai.node.deciders.binary_decider import BinaryDecider, QuantileBinaryDecider
+from cuvis_ai.node.deciders.two_stage_decider import TwoStageBinaryDecider
+
+pytestmark = pytest.mark.unit
+
+HIGH = 5.0  # raw anomaly score; sigmoid(5) is well clear of sigmoid(0)
+
+
+def _frame_level_split(n_normal: int = 3, n_anom: int = 3, size: int = 8):
+    """Frames with a bright 2x2 anomaly block (anomalous) or all-zero (normal).
+
+    Returns ``(scores [N,H,W,1] float32, targets [N,H,W,1] bool)`` with normal frames first.
+    """
+    total = n_normal + n_anom
+    scores = torch.zeros(total, size, size, 1)
+    targets = torch.zeros(total, size, size, 1, dtype=torch.bool)
+    for i in range(n_normal, total):
+        scores[i, 1:3, 1:3, 0] = HIGH
+        targets[i, 1:3, 1:3, 0] = True
+    return scores, targets
+
+
+def test_binary_decider_calibrate_reproduces_gt():
+    scores, targets = _frame_level_split()
+    decider = BinaryDecider(threshold=0.5)
+    report = decider.calibrate(scores, targets)
+
+    assert report["f1"] == pytest.approx(1.0)
+    # forward thresholds sigmoid(logits); after calibration it must reproduce the GT exactly.
+    decisions = decider.forward(logits=scores)["decisions"]
+    assert torch.equal(decisions, targets)
+    # the shipped default 0.5 would flag every pixel (sigmoid(0)=0.5>=0.5) - calibration moved it
+    assert decider.threshold > 0.5
+
+
+def test_quantile_decider_calibrate_finds_fraction():
+    # every frame: 10 anomalous pixels (of 100) at HIGH, rest zero -> optimal cutoff flags 10%.
+    n, size = 4, 10
+    scores = torch.zeros(n, size, size, 1)
+    targets = torch.zeros(n, size, size, 1, dtype=torch.bool)
+    scores[:, 0, :, 0] = HIGH  # top row = 10 pixels
+    targets[:, 0, :, 0] = True
+    decider = QuantileBinaryDecider(quantile=0.5)
+    report = decider.calibrate(scores, targets)
+
+    assert report["f1"] == pytest.approx(1.0)
+    decisions = decider.forward(logits=scores)["decisions"]
+    assert torch.equal(decisions, targets)
+
+
+def test_two_stage_decider_calibrate_gate_and_pixel():
+    scores, targets = _frame_level_split()
+    decider = TwoStageBinaryDecider(image_threshold=0.5, pixel_threshold=None)
+    report = decider.calibrate(scores, targets)
+
+    assert report["image_f1"] == pytest.approx(1.0)
+    assert report["pixel_f1"] == pytest.approx(1.0)
+    # stage 2 moved off the quantile fallback onto an absolute cutoff.
+    assert decider.pixel_threshold is not None
+    decisions = decider.forward(logits=scores)["decisions"]
+    assert torch.equal(decisions, targets)
+
+
+@pytest.mark.parametrize(
+    ("decider", "keys"),
+    [
+        (BinaryDecider(threshold=0.5), ["threshold"]),
+        (QuantileBinaryDecider(quantile=0.5), ["quantile"]),
+        (TwoStageBinaryDecider(image_threshold=0.5), ["image_threshold", "pixel_threshold"]),
+    ],
+)
+def test_calibrate_updates_live_attr_and_hparams(decider, keys):
+    """The live attribute, ``hparams`` (yaml source) and the report all agree post-calibrate."""
+    scores, targets = _frame_level_split()
+    report = decider.calibrate(scores, targets)
+    for key in keys:
+        live = getattr(decider, key)
+        assert decider.hparams[key] == live  # yaml will carry the calibrated value
+        assert report[key]["new"] == live  # report matches what was written
+
+
+def test_calibrate_survives_hparam_reconstruction():
+    """Rebuilding a decider from its post-calibration hparams keeps the calibrated values."""
+    scores, targets = _frame_level_split()
+    decider = TwoStageBinaryDecider(image_threshold=0.5, pixel_threshold=None)
+    decider.calibrate(scores, targets)
+    rebuilt = TwoStageBinaryDecider(
+        image_threshold=decider.hparams["image_threshold"],
+        top_k_fraction=decider.hparams["top_k_fraction"],
+        quantile=decider.hparams["quantile"],
+        pixel_threshold=decider.hparams["pixel_threshold"],
+    )
+    assert rebuilt.image_threshold == decider.image_threshold
+    assert rebuilt.pixel_threshold == decider.pixel_threshold
+    assert torch.equal(rebuilt.forward(logits=scores)["decisions"], targets)

--- a/tests/deciders/test_decider_calibration.py
+++ b/tests/deciders/test_decider_calibration.py
@@ -5,14 +5,19 @@ labelled validation scores and writes the result to both the live attribute (so 
 uses it) and ``hparams`` (so it serialises into the pipeline yaml). The golden tests build a
 cleanly separable synthetic split, calibrate, and assert the recalibrated decider reproduces
 the ground truth in ``forward`` - the end-to-end contract - plus the live/hparam/report
-consistency that makes the value persist.
+consistency that makes the value persist. The numeric tests check that what the sweep scored
+is what ``forward`` decides (float32 pixel space, float64 image gate, sigmoid saturation),
+and that the ``calibrate-thresholds`` CLI ships the same values as the methods.
 """
 
+import numpy as np
 import pytest
 import torch
 
+from cuvis_ai.node.deciders import _calibration as calib
 from cuvis_ai.node.deciders.binary_decider import BinaryDecider, QuantileBinaryDecider
 from cuvis_ai.node.deciders.two_stage_decider import TwoStageBinaryDecider
+from cuvis_ai_core.pipeline.factory import PipelineBuilder
 
 pytestmark = pytest.mark.unit
 
@@ -33,6 +38,25 @@ def _frame_level_split(n_normal: int = 3, n_anom: int = 3, size: int = 8):
     return scores, targets
 
 
+def _random_split(seed: int = 0, n: int = 4, size: int = 16):
+    """Random float32 logits with ties and a sparse random mask, as tensors."""
+    rng = np.random.default_rng(seed)
+    scores = torch.from_numpy(
+        (rng.integers(-20, 20, size=(n, size, size, 1)) / 10).astype(np.float32)
+    )
+    targets = torch.from_numpy(rng.random((n, size, size, 1)) < 0.05)
+    targets[0, 0, 0, 0] = True
+    targets[1, 0, 0, 0] = False
+    return scores, targets
+
+
+def _f1(decisions: torch.Tensor, targets: torch.Tensor) -> float:
+    tp = float((decisions & targets).sum())
+    fp = float((decisions & ~targets).sum())
+    fn = float((~decisions & targets).sum())
+    return calib.prf(tp, fp, fn)["f1"]
+
+
 def test_binary_decider_calibrate_reproduces_gt():
     scores, targets = _frame_level_split()
     decider = BinaryDecider(threshold=0.5)
@@ -44,6 +68,12 @@ def test_binary_decider_calibrate_reproduces_gt():
     assert torch.equal(decisions, targets)
     # the shipped default 0.5 would flag every pixel (sigmoid(0)=0.5>=0.5) - calibration moved it
     assert decider.threshold > 0.5
+    # The sweep ran in float32 sigmoid space; the value is the plateau midpoint between the two
+    # probability levels and is exact in float32.
+    high = float(torch.sigmoid(torch.tensor(HIGH)))
+    assert decider.threshold == pytest.approx((0.5 + high) / 2, abs=1e-6)
+    assert np.float32(decider.threshold) == decider.threshold
+    assert report["on_point_threshold"] == pytest.approx(high)
 
 
 def test_quantile_decider_calibrate_finds_fraction():
@@ -61,6 +91,24 @@ def test_quantile_decider_calibrate_finds_fraction():
     assert torch.equal(decisions, targets)
 
 
+def test_quantile_decider_reduce_dims_equivalent_to_default_still_calibrates():
+    # reduce_dims=[1, 2] on single-channel input reduces the same values as the default.
+    scores, targets = _frame_level_split()
+    decider = QuantileBinaryDecider(quantile=0.5, reduce_dims=[1, 2])
+    report = decider.calibrate(scores, targets)
+    assert report is not None
+    assert decider.hparams["quantile"] == decider.quantile
+
+
+def test_quantile_decider_refuses_reduce_dims_it_cannot_reproduce():
+    scores, targets = _frame_level_split()
+    scores = scores.repeat(1, 1, 1, 3)  # three channels: reduce_dims=[1, 2] keeps the C axis
+    decider = QuantileBinaryDecider(quantile=0.5, reduce_dims=[1, 2])
+    with pytest.raises(calib.CalibrationError, match="reduce_dims"):
+        decider.calibrate(scores, targets)
+    assert decider.quantile == 0.5 and decider.hparams["quantile"] == 0.5
+
+
 def test_two_stage_decider_calibrate_gate_and_pixel():
     scores, targets = _frame_level_split()
     decider = TwoStageBinaryDecider(image_threshold=0.5, pixel_threshold=None)
@@ -72,6 +120,25 @@ def test_two_stage_decider_calibrate_gate_and_pixel():
     assert decider.pixel_threshold is not None
     decisions = decider.forward(logits=scores)["decisions"]
     assert torch.equal(decisions, targets)
+    # Both values sit at the midpoint of the plateau between the normal (0) and anomalous (5)
+    # levels, not on the anomalous samples themselves.
+    assert decider.image_threshold == 2.5
+    assert decider.pixel_threshold == 2.5
+    assert report["on_point"] == {"image_threshold": HIGH, "pixel_threshold": HIGH}
+
+
+def test_two_stage_decider_default_gate_off_gets_calibrated():
+    """The CuvisNEXT training presets ship both thresholds as null; calibration fills them."""
+    scores, targets = _frame_level_split()
+    decider = TwoStageBinaryDecider()
+    report = decider.calibrate(scores, targets)
+
+    assert report["image_threshold"]["old"] is None
+    assert report["pixel_threshold"]["old"] is None
+    assert decider.image_threshold == 2.5 and decider.pixel_threshold == 2.5
+    assert report["joint"]["f1"] >= report["pixel_f1"]
+    assert {"image_threshold", "pixel_threshold"} <= report["joint"].keys()
+    assert torch.equal(decider.forward(logits=scores)["decisions"], targets)
 
 
 @pytest.mark.parametrize(
@@ -106,3 +173,84 @@ def test_calibrate_survives_hparam_reconstruction():
     assert rebuilt.image_threshold == decider.image_threshold
     assert rebuilt.pixel_threshold == decider.pixel_threshold
     assert torch.equal(rebuilt.forward(logits=scores)["decisions"], targets)
+
+
+def test_calibrated_values_survive_the_pipeline_yaml_round_trip(tmp_path):
+    """save_to_file writes the calibrated hparams; a pipeline built from that yaml has them."""
+    scores, targets = _frame_level_split()
+    config = {
+        "metadata": {"name": "calibrated"},
+        "nodes": [
+            {
+                "name": "decider",
+                "class_name": ("cuvis_ai.node.deciders.two_stage_decider.TwoStageBinaryDecider"),
+                "hparams": {"image_threshold": 0.5, "pixel_threshold": None},
+            }
+        ],
+        "connections": [],
+    }
+    pipeline = PipelineBuilder().build_from_config(config)
+    decider = next(node for node in pipeline.nodes if node.name == "decider")
+    decider.calibrate(scores, targets)
+
+    yaml_path = tmp_path / "calibrated.yaml"
+    pipeline.save_to_file(yaml_path, save_weights=False)
+    text = yaml_path.read_text(encoding="utf-8")
+    assert "image_threshold: 2.5" in text and "pixel_threshold: 2.5" in text
+
+    rebuilt = PipelineBuilder().build_from_config(yaml_path)
+    node = next(n for n in rebuilt.nodes if n.name == "decider")
+    assert node.image_threshold == 2.5 and node.pixel_threshold == 2.5
+    assert torch.equal(node.forward(logits=scores)["decisions"], targets)
+
+
+def test_forward_reproduces_the_sweep_on_random_scores():
+    """Float32 pixel space and float64 gate: forward's F1 equals the F1 the sweep reported."""
+    scores, targets = _random_split(seed=3)
+    two_stage = TwoStageBinaryDecider(image_threshold=0.5, top_k_fraction=0.02)
+    report = two_stage.calibrate(scores, targets)
+    assert np.float32(two_stage.pixel_threshold) == two_stage.pixel_threshold
+    decisions = two_stage.forward(logits=scores)["decisions"]
+    assert _f1(decisions, targets) == pytest.approx(report["pixel_f1"], abs=1e-12)
+
+    binary = BinaryDecider(threshold=0.5)
+    report = binary.calibrate(scores, targets)
+    assert np.float32(binary.threshold) == binary.threshold
+    decisions = binary.forward(logits=scores)["decisions"]
+    assert _f1(decisions, targets) == pytest.approx(report["f1"], abs=1e-12)
+
+
+def test_binary_decider_saturated_logits_report_what_forward_can_do():
+    """Above logits of ~17 float32 sigmoid is exactly 1.0: the sweep must not claim to separate."""
+    scores = torch.full((2, 4, 4, 1), 20.0)
+    targets = torch.zeros(2, 4, 4, 1, dtype=torch.bool)
+    scores[1, :2, :2, 0] = 40.0
+    targets[1, :2, :2, 0] = True
+    decider = BinaryDecider(threshold=0.5)
+    report = decider.calibrate(scores, targets)
+    decisions = decider.forward(logits=scores)["decisions"]
+    assert report["f1"] < 1.0
+    assert _f1(decisions, targets) == pytest.approx(report["f1"], abs=1e-12)
+
+
+def test_cli_ships_the_same_values_as_the_decider_methods():
+    """The calibrate-thresholds CLI and calibrate() are one implementation."""
+    from scripts.calibrate_thresholds import _binary_hparams, _two_stage_hparams
+
+    scores, targets = _random_split(seed=4)
+    _, pixel, gt, frame_labels = calib.reduce_scores_targets(scores, targets)
+
+    two_stage = TwoStageBinaryDecider(image_threshold=0.5, top_k_fraction=0.02)
+    two_stage.calibrate(scores, targets)
+    image_scores = calib.topk_mean_scores(pixel, 0.02)
+    best_image, _joint, conditional = calib.sweep_two_stage(
+        pixel, gt, image_scores, frame_labels, 256
+    )
+    cli = _two_stage_hparams(best_image, conditional, 0.02)
+    assert cli["image_threshold"] == two_stage.hparams["image_threshold"]
+    assert cli["pixel_threshold"] == two_stage.hparams["pixel_threshold"]
+
+    binary = BinaryDecider(threshold=0.5)
+    binary.calibrate(scores, targets)
+    best = calib.sweep_absolute(calib.sigmoid_float32(pixel), gt, 256)
+    assert _binary_hparams(best)["threshold"] == binary.hparams["threshold"]


### PR DESCRIPTION

- `BinaryDecider`, `QuantileBinaryDecider` and `TwoStageBinaryDecider` gain `calibrate(scores, targets)`: re-fit the decider's own decision rule to F1-max on a labelled validation split, written to the live attribute and to `hparams`, so the saved pipeline yaml carries the value (the `.pt` is unchanged). This is the node half of the in-training calibration phase; the trainrun hook lands in cuvis-ai-core.
- The F1-max sweep math moved from `scripts/calibrate_thresholds.py` into the shared `cuvis_ai/node/deciders/_calibration.py`; the CLI and the new methods run the same code and report the same values.
- Calibrated thresholds are exact in float32 (the space the deciders compare in) and sit at the midpoint of the F1-max plateau instead of on a validation sample; the two-stage gate reuses the exact stage-1 statistic of `forward`.
- `BinaryDecider` calibration sweeps float32 sigmoid probabilities directly, so saturated logits no longer map to an unreachable threshold; the CLI binary mode follows.
- `CalibrationError` (a `ValueError`) names the bad input: mismatched shapes, non-finite scores, single-class targets, or a `QuantileBinaryDecider.reduce_dims` the sweep cannot honour.
- The sweeps count true and false positives for all candidates in one pass per frame (sorted scores plus `searchsorted`), so calibration on a large validation split no longer scans every pixel once per candidate.


Pairs with the trainrun hook in cubert-hyperspectral/cuvis-ai-core#72 (independent to merge; the feature is active in CuvisNEXT once both are released and the managed env is relocked). Review follow-ups landed on the branch as 0d25087.
