### PR TITLE
release: cuvis-ai 0.15.0 (plugin weights from the cubert-gmbh mirrors, model-weights docs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,9 @@ LOG_FORMAT=json
 DATA_DIR=./data
 
 # HuggingFace API Configuration
-# HuggingFace API Token (optional, for private models/spaces)
+# HuggingFace API Token (optional). Plugin model weights (SAM3, EfficientTAM, DINOv2,
+# CLIP, AdaCLIP) come from the public cubert-gmbh mirrors and need no token; set one
+# only for private or custom repos passed to `download-model download --repo-id`.
 # Get your token from: https://huggingface.co/settings/tokens
 HF_TOKEN=your_huggingface_token_here
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.15.0 - unreleased
+
+- **Plugin model weights come from the public `cubert-gmbh` Hugging Face mirrors; no Hugging Face account or token is needed any more.** The manifest pins move to the plugin releases that resolve their weights through the cuvis-ai-core 0.16.0 registry: `sam3` v0.4.0 (SAM3 checkpoint from `cubert-gmbh/sam3`), `rtsam2` v0.4.0 (EfficientTAM from `cubert-gmbh/efficient-track-anything`, now including the 512x512 variants), `adaclip` v0.4.0 (CLIP backbone and AdaCLIP heads from `cubert-gmbh/clip` and `cubert-gmbh/adaclip`, `gdown` dropped) and `dinomaly` v0.7.0 (DINOv2 backbone from `cubert-gmbh/dinov2`). Core floor raised to `cuvis-ai-core>=0.16.0`. The cache folder names change (`models--cubert-gmbh--*`), so an existing install downloads its weights once more; `uv run download-model download <name>` provisions them ahead of an offline gRPC run.
+- **New docs page [Model Weights](docs/workflows/model-weights.md)**: which weights each plugin downloads, `download-model list` and `download` usage, provisioning for the offline child runtime, custom or private weights, and the licence of every mirrored file. `.env.example` now says `HF_TOKEN` is only needed for private or custom repos.
+
 ## 0.14.0 - 2026-09-04
 
 - **`TwoStageBinaryDecider.image_threshold` is optional and defaults to `None` (gate off).** With no gate every frame reaches stage 2; with `pixel_threshold` also unset the node produces the same decisions as `QuantileBinaryDecider` for `[B, H, W, 1]` input (tested bit for bit). A value that is not a finite number (a string, a bool) is refused by name instead of being coerced; the same check now covers `pixel_threshold`. Behaviour change only for `TwoStageBinaryDecider()` with no arguments (the old default gated at 0.5 in raw score space); every shipped preset that uses the class sets `image_threshold` explicitly. Per-frame debug logging is lazy, so a live camera path no longer pays whole-tensor `.item()` syncs when debug is off.

--- a/cuvis_ai/configs/plugins/adaclip.yaml
+++ b/cuvis_ai/configs/plugins/adaclip.yaml
@@ -7,7 +7,7 @@
 name: adaclip
 # AdaCLIP-based anomaly detection with advanced band selection
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-adaclip.git"
-tag: "v0.3.2"
+tag: "v0.4.0"
 package_name: "cuvis-ai-adaclip"
 capabilities:
 - class_name: cuvis_ai_adaclip.node.adaclip_node.AdaCLIPDetector

--- a/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_builtin.yaml
@@ -9,7 +9,7 @@
 name: cuvis_ai_builtin
 package_name: cuvis-ai
 repo: https://github.com/cubert-hyperspectral/cuvis-ai.git
-tag: "v0.14.0"
+tag: "v0.15.0"
 capabilities:
 - class_name: cuvis_ai.node.anomaly.deep_svdd.DeepSVDDCenterTracker
   category: transform

--- a/cuvis_ai/configs/plugins/dinomaly.yaml
+++ b/cuvis_ai/configs/plugins/dinomaly.yaml
@@ -8,7 +8,7 @@ name: dinomaly
 # Local development override (optional):
 # path: "../../../cuvis-ai-dinomaly"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dinomaly.git"
-tag: "v0.6.4"
+tag: "v0.7.0"
 package_name: "cuvis-ai-dinomaly"
 capabilities:
 - class_name: cuvis_ai_dinomaly.node.dinomaly_detector.DinomalyDetector

--- a/cuvis_ai/configs/plugins/rtsam2.yaml
+++ b/cuvis_ai/configs/plugins/rtsam2.yaml
@@ -10,7 +10,7 @@ name: rtsam2
 # For local development against a checkout, comment the repo/tag pin and use:
 # path: "D:/code-repos/cuvis-ai-rtsam2/cuvis-ai-rtsam2"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-rtsam2.git"
-tag: "v0.3.1"
+tag: "v0.4.0"
 package_name: "cuvis-ai-rtsam2"
 capabilities:
 - class_name: cuvis_ai_rtsam2.node.rtsam2_streaming_propagation.RTSAM2BboxPropagation

--- a/cuvis_ai/configs/plugins/sam3.yaml
+++ b/cuvis_ai/configs/plugins/sam3.yaml
@@ -7,7 +7,7 @@
 name: sam3
 # SAM3-based video object tracking plugin.
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-sam3.git"
-tag: "v0.3.3"  # decord gated to platforms with wheels (aarch64 child envs compose)
+tag: "v0.4.0"  # decord gated to platforms with wheels (aarch64 child envs compose)
 package_name: "cuvis-ai-sam3"
 capabilities:
 - class_name: cuvis_ai_sam3.node.SAM3TextPropagation

--- a/docs/deployment/grpc-deployment.md
+++ b/docs/deployment/grpc-deployment.md
@@ -152,6 +152,7 @@ spec:
 ## Troubleshooting
 
 - `NOT_FOUND` errors: verify `session_id` exists and was not closed.
+- `ModelWeightsMissingError` while loading a pipeline: the child runtime runs offline and without credentials by design. Provision the weight on the server host first with `uv run download-model download <name>` (see [Model Weights](../workflows/model-weights.md)).
 - Message size exceeded: raise `grpc.max_send_message_length` / `grpc.max_receive_message_length` on both client and server.
 - Slow throughput: increase thread pool size or reduce batch sizes.
 - Port conflicts: choose an available port or free the existing listener.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -143,5 +143,6 @@ uv run python -m pytest tests/ -v --tb=line -m "not slow and not gpu"
 ## Next steps
 
 * **[Quickstart](quickstart.md)**
+* **[Model Weights](../workflows/model-weights.md)** (pretrained plugin weights, no Hugging Face account needed)
 * **[Configuration](../reference/configuration/index.md)**
 * **[Use Cases](../tutorials/index.md)**

--- a/docs/reference/plugin-development/guide.md
+++ b/docs/reference/plugin-development/guide.md
@@ -41,6 +41,7 @@ build-backend = "hatchling.build"
 - Define `INPUT_SPECS` and `OUTPUT_SPECS`.
 - Implement `forward()`.
 - Pass serializable constructor arguments through `super().__init__(...)`.
+- Load pretrained weights through `ModelWeights.resolve()` or `ModelWeights.materialize()` from `cuvis_ai_core.data.model_weights` instead of hardcoding an upstream repo id, so the offline child runtime finds what `download-model` provisioned (see [Model Weights](../../workflows/model-weights.md)).
 
 ## Manifest for Local Development
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -53,6 +53,12 @@ If you're new and need step-by-step learning instead, start with
 
     Replay a saved pipeline with `restore-pipeline` or `restore-trainrun`.
 
+-   :material-download: **[Model Weights](model-weights.md)**
+
+    ---
+
+    Pretrained plugin weights from the public Cubert mirrors: list, provision, run offline.
+
 -   :material-monitor-eye: **[Monitoring & Visualization](monitoring.md)**
 
     ---

--- a/docs/workflows/model-weights.md
+++ b/docs/workflows/model-weights.md
@@ -1,0 +1,122 @@
+# Model Weights
+
+Several plugins load pretrained weights on first use: SAM3 (`sam3`), EfficientTAM (`rtsam2`),
+the DINOv2 backbone (`dinomaly`), and the CLIP backbone plus the fine-tuned heads (`adaclip`).
+From cuvis-ai-core 0.16.0 every one of these files is served from a public Hugging Face
+repository under the [`cubert-gmbh`](https://huggingface.co/cubert-gmbh) organisation:
+byte-identical to the upstream release, pinned to a mirror commit, and sha256-verified on
+download. No Hugging Face account, token, or licence click-through is needed.
+
+The registry in `cuvis_ai_core.data.model_weights.ModelWeights` is the single source of truth
+for where a weight lives. Plugins resolve their checkpoints through it instead of hardcoding an
+upstream repo id, so the tool that provisions a weight and the runtime that loads it always look
+in the same cache folder.
+
+## What is registered
+
+| Registry name | Plugin | Mirror repository | File | Licence |
+|---|---|---|---|---|
+| `sam3` | sam3 | `cubert-gmbh/sam3` | `sam3.pt` (+ `config.json`) | SAM License |
+| `efficienttam_s`, `efficienttam_ti` | rtsam2 | `cubert-gmbh/efficient-track-anything` | `efficienttam_s.pt`, `efficienttam_ti.pt` | Apache-2.0 |
+| `efficienttam_s_512x512`, `efficienttam_ti_512x512` | rtsam2 | `cubert-gmbh/efficient-track-anything` | 512x512 input variants | Apache-2.0 |
+| `dinov2_vitb14_reg4` | dinomaly | `cubert-gmbh/dinov2` | `dinov2_vitb14_reg4_pretrain.pth` | Apache-2.0 |
+| `clip_vit_l_14_336` | adaclip | `cubert-gmbh/clip` | `ViT-L-14-336px.pt` | unspecified upstream (code: MIT) |
+| `adaclip_all`, `adaclip_mvtec_colondb`, `adaclip_visa_clinicdb` | adaclip | `cubert-gmbh/adaclip` | `pretrained_*.pth` | unspecified upstream (code: MIT) |
+
+Each mirror repository carries the upstream `LICENSE` file verbatim and a model card with the
+provenance: upstream source, upstream revision, and the sha256 of every file. The SAM License
+governs the SAM3 checkpoint; read it before shipping a product that embeds these weights.
+
+`download-model list` prints the live table. `download-model list --json` emits one object per
+entry with `name`, `plugin`, `repo_id`, `filename`, `revision`, `sha256`, `aux_files`,
+`license`, `requires_token` and `cache_dir_token` (the `models--cubert-gmbh--<repo>` folder
+name), for tooling that needs to know what a pipeline will pull.
+
+```bash
+uv run download-model list
+uv run download-model list --json
+```
+
+## Where the files go
+
+Weights land in the Hugging Face hub cache: `HF_HUB_CACHE` if set, else `HF_HOME/hub`, else the
+huggingface_hub default (`~/.cache/huggingface/hub`). Every mirror gets its own folder, for
+example `models--cubert-gmbh--sam3/snapshots/<commit>/sam3.pt`.
+
+!!! note "Upgrading from cuvis-ai 0.14 or earlier"
+    The folder names changed with the move to the mirrors (previously `models--facebook--sam3`
+    and friends), so an existing install downloads its weights once more. Nothing else migrates.
+
+## Provision ahead of time
+
+In a notebook or a script that runs online, the plugin nodes download what they need on first
+use. Pre-fetching is still worth it for a large file (SAM3 is 3.4 GB) or for a machine that goes
+offline later:
+
+```bash
+uv run download-model download sam3
+uv run download-model download efficienttam_s
+uv run download-model download dinov2_vitb14_reg4
+uv run download-model download clip_vit_l_14_336
+uv run download-model download adaclip_all
+```
+
+Each command validates the sha256 pin, fetches the companion files (`config.json` for SAM3), and
+prints the resolved path on stdout so it composes with other tools. `--force` re-downloads a
+cached file. `--out <path>` additionally copies the file to a location of your choice, for
+example to hand it to a node's checkpoint-path hyperparameter.
+
+## The gRPC child runtime is offline
+
+The orchestrated gRPC server runs every pipeline in a per-run child environment with
+`HF_HUB_OFFLINE=1` and no credentials (see [gRPC Deployment](../deployment/grpc-deployment.md)).
+The child can only load weights that are already in the cache, and it resolves the same cache
+the provisioner writes to (`HF_HUB_CACHE` is exported to it explicitly). Provision the weights on
+the server host before the first run of a pipeline that needs them:
+
+```bash
+uv run download-model download sam3      # once per weight, on the host that runs the server
+```
+
+A run whose weight is missing fails while the pipeline loads, naming the command to run:
+
+```text
+ModelWeightsMissingError: 'sam3' is not in the model cache (...). Provision it with: uv run download-model download sam3
+```
+
+## Custom or private weights
+
+The registry is the default, not a lock-in.
+
+- `download-model download <name> --repo-id <org/repo> --filename <file> --revision <ref> --out <path>`
+  fetches from another Hugging Face repository (a fork, a private mirror). `--token` defaults
+  to `$HF_TOKEN` and is only needed for a private repository.
+
+- A file fetched from a custom repository is not what the plugin's registry lookup finds, so
+  point the node at it: the SAM3, RTSAM2 and AdaCLIP nodes accept a local checkpoint path or
+  model directory hyperparameter (see the node's reference page in the
+  [Nodes catalog](../catalogs/nodes/index.md)).
+
+## For plugin authors
+
+```python
+from cuvis_ai_core.data.model_weights import ModelWeights
+
+path = ModelWeights.resolve("sam3")                  # cached path; downloads when online
+path = ModelWeights.resolve("sam3", download=False)  # pure lookup; raises when missing
+seed = ModelWeights.materialize("dinov2_vitb14_reg4", vendored_dir)  # hardlink or copy
+```
+
+- `resolve(name, download=None)` returns the cached file. The default for `download` is
+  "allowed unless `HF_HUB_OFFLINE` is set", so the same call works in a notebook and in the
+  offline child. A miss with downloading disallowed raises `ModelWeightsMissingError`.
+
+- `materialize(name, dest_dir, filename=None)` places a hardlink (or a copy, when linking is
+  not possible) at a fixed path for loaders that cannot read the hub cache layout, such as
+  anomalib's DINOv2 loader or the vendored CLIP loader. An existing destination is never
+  overwritten.
+
+- New weights belong in the core registry as a `cubert-gmbh` mirror (built with
+  `tools/mirror_weights.py` in cuvis-ai-core) rather than behind an upstream URL inside the
+  plugin; otherwise the offline child cannot find them. See the
+  [Plugin Development Guide](../reference/plugin-development/guide.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
       - Build Pipeline (Python): workflows/build-pipeline-python.md
       - Build Pipeline (YAML): workflows/build-pipeline-yaml.md
       - Restore Pipeline: workflows/restore-pipeline.md
+      - Model Weights: workflows/model-weights.md
       - Statistical Training: workflows/statistical-training.md
       - Gradient Training: workflows/gradient-training.md
       - Monitoring & Visualization: workflows/monitoring.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # plugin behind its [cu3s] extra, provisioned at runtime when a cu3s run needs it.
     # Builtin/RGB pipelines pull neither cuvis nor cuvis-il, closing the Windows wheel gap.
     # Tests mock the data layer (no plugin dep); the real cu3s reader is tested in the plugin.
-    "cuvis-ai-core>=0.15.0",
+    "cuvis-ai-core>=0.16.0",
     "cuvis-ai-schemas[full]>=0.10.0",
     "pydantic>=2.13.3,<3.0.0",
     "defusedxml>=0.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -815,7 +815,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "cuvis-ai-core", specifier = ">=0.15.0" },
+    { name = "cuvis-ai-core", specifier = ">=0.16.0" },
     { name = "cuvis-ai-schemas", extras = ["full"], specifier = ">=0.10.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
@@ -887,7 +887,7 @@ dev = [
 
 [[package]]
 name = "cuvis-ai-core"
-version = "0.15.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -921,9 +921,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ab/c9035e06b05681a3ee909ceb1130c1f24577ba36905b4b2aac6cb4898b40/cuvis_ai_core-0.15.0.tar.gz", hash = "sha256:e287256d20b94ae1ce3741e305ad2060ff0ed403697ee521a3d875ee4bb04685", size = 804015, upload-time = "2026-09-04T09:37:55.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/e9/0a14b828a226c0759a873748717425d09a1ab6268b218dac5d4b33bd0dc9/cuvis_ai_core-0.16.0.tar.gz", hash = "sha256:471e6250b77a904a00e77d139debd7e8fb5713f35167aa2985e652ef84e59d89", size = 819713, upload-time = "2026-09-04T12:53:10.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/a6/508b95a8d7941a11a9e2e754cf2e9b8828e79d4be4396a52e90d3fd46af3/cuvis_ai_core-0.15.0-py3-none-any.whl", hash = "sha256:0b8dcd53add3a7b2376234c99b62adde4393b6a7a73f819be5e568c7eb22c1cc", size = 265889, upload-time = "2026-09-04T09:37:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/22/662ba831346bb048c6a27b83c866ba33cc26f9d8f6c03f54468b2221d1f2/cuvis_ai_core-0.16.0-py3-none-any.whl", hash = "sha256:45683abbfb8660a518ead721f3dcac208cb7c34b3f0763923d3b569a88e2fe33", size = 266804, upload-time = "2026-09-04T12:53:08.95Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

- **Plugin model weights come from the public `cubert-gmbh` Hugging Face mirrors; no Hugging Face account or token is needed any more.** The manifest pins move to the plugin releases that resolve their weights through the cuvis-ai-core 0.16.0 registry: `sam3` v0.4.0 (SAM3 checkpoint from `cubert-gmbh/sam3`), `rtsam2` v0.4.0 (EfficientTAM from `cubert-gmbh/efficient-track-anything`, now including the 512x512 variants), `adaclip` v0.4.0 (CLIP backbone and AdaCLIP heads from `cubert-gmbh/clip` and `cubert-gmbh/adaclip`, `gdown` dropped) and `dinomaly` v0.7.0 (DINOv2 backbone from `cubert-gmbh/dinov2`). Core floor raised to `cuvis-ai-core>=0.16.0`. The cache folder names change (`models--cubert-gmbh--*`), so an existing install downloads its weights once more; `uv run download-model download <name>` provisions them ahead of an offline gRPC run.
- **New docs page [Model Weights](docs/workflows/model-weights.md)**: which weights each plugin downloads, `download-model list` and `download` usage, provisioning for the offline child runtime, custom or private weights, and the licence of every mirrored file. `.env.example` now says `HF_TOKEN` is only needed for private or custom repos.


Verification: `mkdocs build --strict` clean; `tests/docs`, `tests/plugins`, `tests/configs` 213 passed; token-free end-to-end `download-model download` of sam3, efficienttam_s, dinov2_vitb14_reg4, clip_vit_l_14_336 and adaclip_all into a fresh cache with every sha256 pin matching.
