### PR TITLE
release: cuvis-ai 0.16.2 (dataloader v0.6.3, cu3s opens only the recordings a run uses)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.16.2 - 2026-09-10
+
+- **The cu3s data module opens only the recordings a run uses.** `configs/plugins/cuvis_ai_dataloader.yaml` moves to `v0.6.3`, which takes the assigned recordings as an explicit `files` list (what CuvisNEXT now sends) and, without one, narrows a folder by the sources the split's selectors name. Enumeration previously built a full reader for every `*.cu3s` under `data_dir` before any selector was applied: an SDK session, a processing context and a read of measurement 0 each. `configs/trainrun/dinomaly_custom_cuvisnext.yaml` documents the list next to `data_dir`; the key stays absent so the preset still runs against an older data module.
+- Floor `cuvis-ai-core>=0.17.2`, which warns when a selector matches some of what it asked for but not all: a `file_indices` selector naming frames a recording does not have used to train on the subset silently.
+
 ## 0.16.1 - 2026-09-09
 
 - **One training preset for the CuvisNEXT Train wizard: `dinomaly_custom`.** New `configs/pipeline/anomaly/dinomaly/dinomaly_custom.yaml` is the Dinomaly training pipeline on a fixed 542/902/886 nm three-band projection (`FixedWavelengthSelector` named `custom_selector`: the bands AdaCLIP's concrete channel selector converged to on the lentils dataset), the recipe of the 2026-09-01 user training, brought onto the current preset contract: `TwoStageBinaryDecider` with `image_threshold: null` and `pixel_threshold: null`, `pixel_stride: 2` on both metric nodes. New `configs/trainrun/dinomaly_custom_cuvisnext.yaml` runs it for the gRPC `RestoreTrainRun` path: 20 epochs, AdamW 2e-3, `reduce_on_plateau` (patience 3) and early stopping (patience 5) on `metrics_auroc/auroc_pixel`, the checkpoint on the same metric with `save_last`, `release_cuda_cache_on_validation: true`. The wizard offers this trainrun and starts it with these values unless its Advanced step edits them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.16.2 - 2026-09-10
 
 - **The cu3s data module opens only the recordings a run uses.** `configs/plugins/cuvis_ai_dataloader.yaml` moves to `v0.6.3`, which takes the assigned recordings as an explicit `files` list (what CuvisNEXT now sends) and, without one, narrows a folder by the sources the split's selectors name. Enumeration previously built a full reader for every `*.cu3s` under `data_dir` before any selector was applied: an SDK session, a processing context and a read of measurement 0 each. `configs/trainrun/dinomaly_custom_cuvisnext.yaml` documents the list next to `data_dir`; the key stays absent so the preset still runs against an older data module.
+- **Security: `pytorch-lightning>=2.6.6`** (PYSEC-2026-3967). Through 2.6.5, `_load_state` imports and executes module names taken from a checkpoint's `_instantiator` hyperparameters, which gets past `weights_only=True`, so `LightningModule.load_from_checkpoint` on a checkpoint from an untrusted source was remote code execution. Every trainrun restore path loads checkpoints that way.
 - Floor `cuvis-ai-core>=0.17.2`, which warns when a selector matches some of what it asked for but not all: a `file_indices` selector naming frames a recording does not have used to train on the subset silently.
 
 ## 0.16.1 - 2026-09-09

--- a/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
+++ b/cuvis_ai/configs/plugins/cuvis_ai_dataloader.yaml
@@ -10,7 +10,7 @@
 name: cuvis_ai_dataloader
 # path: "../../../../cuvis-ai-dataloader/cuvis-ai-dataloader"
 repo: "https://github.com/cubert-hyperspectral/cuvis-ai-dataloader.git"
-tag: "v0.6.2"
+tag: "v0.6.3"
 package_name: cuvis-ai-dataloader
 capabilities:
   - class_name: cuvis_ai_dataloader.data.datamodule_cu3s.Cu3sDataModule

--- a/cuvis_ai/configs/trainrun/dinomaly_custom_cuvisnext.yaml
+++ b/cuvis_ai/configs/trainrun/dinomaly_custom_cuvisnext.yaml
@@ -18,7 +18,12 @@ data:
     # and filled in by the caller. Training stages refuse to run without it.
     splits_path: ''
   params:
-    # Absolute path of the cu3s dataset folder; filled in by the caller.
+    # Absolute path of the cu3s dataset folder; filled in by the caller. A fallback:
+    # the caller also fills `files` with the recordings its split assigns (CuvisNEXT
+    # does), and the data module reads that list instead of searching this folder, so
+    # a recording the split does not assign is never opened. Needs
+    # cuvis-ai-dataloader >= 0.6.3; without a list, a split whose selectors all name
+    # their sources still narrows the folder by itself.
     data_dir: ''
     # One sample per measurement per file, enumerated with canonical absolute
     # sources — the contract externally authored splits.json are written against.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "torchvision>=0.26.0",
     "torchcodec>=0.11.1",
     "torchmetrics>=1.9.0",
-    "pytorch-lightning>=2.6.1",
+    "pytorch-lightning>=2.6.6",
     "tzdata>=2026.2; sys_platform == 'win32'",
     "loguru>=0.7.3",
     "packaging>=26.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # plugin behind its [cu3s] extra, provisioned at runtime when a cu3s run needs it.
     # Builtin/RGB pipelines pull neither cuvis nor cuvis-il, closing the Windows wheel gap.
     # Tests mock the data layer (no plugin dep); the real cu3s reader is tested in the plugin.
-    "cuvis-ai-core>=0.17.1",
+    "cuvis-ai-core>=0.17.2",
     "cuvis-ai-schemas[full]>=0.12.0",
     "pydantic>=2.13.3,<3.0.0",
     "defusedxml>=0.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -855,7 +855,7 @@ requires-dist = [
     { name = "pytest-check-links", marker = "extra == 'docs'", specifier = ">=0.9.0" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-md-report", marker = "extra == 'docs'", specifier = ">=0.3.0" },
-    { name = "pytorch-lightning", specifier = ">=2.6.1" },
+    { name = "pytorch-lightning", specifier = ">=2.6.6" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "regex", specifier = ">=2026.4.4" },
     { name = "requests", specifier = ">=2.33.1" },
@@ -3958,7 +3958,7 @@ wheels = [
 
 [[package]]
 name = "pytorch-lightning"
-version = "2.6.1"
+version = "2.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec", extra = ["http"] },
@@ -3970,9 +3970,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/ac/ebd5f6f58691cbd4f73836e43e1727f3814311b960c41f88e259606ca2b2/pytorch_lightning-2.6.1.tar.gz", hash = "sha256:ba08f8901cf226fcca473046ad9346f414e99117762dc869c76e650d5b3d7bdc", size = 665563, upload-time = "2026-01-30T14:59:11.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/e4/5025cb42311b4f8cc6d1b12cd81399ca433159f8e3831ab229c5a6c5177e/pytorch_lightning-2.6.6.tar.gz", hash = "sha256:52c52b20522dd3d3feb3bb3aae2dbe3f291e8e836d4111a74cfd72e9df018834", size = 662507, upload-time = "2026-09-10T09:41:16.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/93/c8c361bf0a2fe50f828f32def460e8b8a14b93955d3fd302b1a9b63b19e4/pytorch_lightning-2.6.1-py3-none-any.whl", hash = "sha256:1f8118567ec829e3055f16cf1aa320883a86a47c836951bfd9dcfa34ec7ffd59", size = 857273, upload-time = "2026-01-30T14:59:10.141Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/ba8e4cc1b982ff6dc6f9fdef0e4074605438b82640f6270888a10e7e42c3/pytorch_lightning-2.6.6-py3-none-any.whl", hash = "sha256:71f95c7b22f25c4f91cc659e1734bcdc6c69c8b66543f2ed2d78dbe29ce2f167", size = 853045, upload-time = "2026-09-10T09:41:14.923Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -815,7 +815,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "cuvis-ai-core", specifier = ">=0.17.1" },
+    { name = "cuvis-ai-core", specifier = ">=0.17.2" },
     { name = "cuvis-ai-schemas", extras = ["full"], specifier = ">=0.12.0" },
     { name = "cyclonedx-bom", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
@@ -887,7 +887,7 @@ dev = [
 
 [[package]]
 name = "cuvis-ai-core"
-version = "0.17.1"
+version = "0.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -921,9 +921,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/be/63af955bf3da42451654367ac29728a65862b9f9cdfbc75afb9a39a49b0e/cuvis_ai_core-0.17.1.tar.gz", hash = "sha256:2a64270705b76dc5a8767f921b70eeb03cf8863b81245e68ad57566bb01d7e16", size = 903368, upload-time = "2026-09-07T12:46:58.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/e666dcfcfce6ce84e1841130b8c245c51a0141dc2fad08ea7ba523aac35c/cuvis_ai_core-0.17.2.tar.gz", hash = "sha256:adbe72001aa3d4353a29de276853fe7b079df733316b39c1e1003c78214a1e4e", size = 904813, upload-time = "2026-09-10T18:46:32.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/67/637d333646a9e6b84c41402f081b6b27f408b9e88bbcfba90cd1f7655741/cuvis_ai_core-0.17.1-py3-none-any.whl", hash = "sha256:f4b344b1d56dd82e4c31ea2f816a3cd557bb03a0d3b7a6c5b0569b2f98494126", size = 317949, upload-time = "2026-09-07T12:46:56.798Z" },
+    { url = "https://files.pythonhosted.org/packages/97/43/e8295d33152339a16bc9c12c5af868de5d0891b283213cc8e0f403a0f175/cuvis_ai_core-0.17.2-py3-none-any.whl", hash = "sha256:7fbfdcee424488229bf8ca214f8abed6b7dd0383ec847f02acaf5ef08e608db5", size = 318605, upload-time = "2026-09-10T18:46:30.823Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`cuvis-ai 0.16.2`: the cu3s data module opens only the recordings a run actually uses.

- `configs/plugins/cuvis_ai_dataloader.yaml` moves to `tag: v0.6.3`.
- `configs/trainrun/dinomaly_custom_cuvisnext.yaml` documents the `files` list next to `data_dir`.
- Floor `cuvis-ai-core>=0.17.2`, relocked.

## Why

Folder-mode enumeration built a full `Cu3sCubeReader` for every `*.cu3s` under `data_dir`
before any selector was applied: an SDK session, a `ProcessingContext` and a read of
measurement 0 each. `data_dir` is the common ancestor of every universe row, assigned or
not, and for a split spanning two drives that ancestor is a drive root. Selectors narrowed
correctly afterwards, so nothing wrong was ever trained on, but every recording under the
ancestor was opened once.

dataloader v0.6.3 takes the assigned recordings as an explicit `files` list, which the
CuvisNEXT training wizard now sends because it already knows them, and without one narrows
a folder by the sources the split's own selectors name, which fixes `restore-trainrun` too.

core 0.17.2 closes the matching blind spot in the resolver: a `file_indices` selector
naming frames a recording does not have used to train on the surviving subset with no
signal anywhere.

## Why the trainrun documents the key instead of carrying it

`Cu3sDataModule` rejects unknown kwargs by design, so an active `files: []` in a shipped
preset would fail against any data module older than 0.6.3, and buys nothing: the GUI
writes the key itself. The comment sits next to `data_dir` where the caller looks.

## Tests

`pytest -m "not slow and not gpu"`: 1448 passed, 10 skipped. `dep_compat` and
`registry_compat` both resolve against the published `v0.6.3` tag.
