### PR TITLE
release: cuvis-ai 0.16.3 (pipeline category tags, cuvisnext view presets for the picker filter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.3 - 2026-09-11
+
+- **Every shipped preset carries one category tag, the word the CuvisNEXT pipeline pickers filter on.** `metadata.tags` of all 42 presets under `configs/pipeline/` now hold exactly one of `anomaly`, `segmentation`, `tracking`, `thickness`, `medical`: 28 already did; `anomaly` joins the adaclip, rx and deep_svdd presets beside their existing tags, `medical` the blood-perfusion NDVI preset. The seven sam3/rtsam2 `*_view` presets are tagged `cuvisnext`, the tag the pickers list by default, alongside the two wafer `_cuvisnext_cube` presets. Nothing is removed: `anomaly_detection` stays on the three presets that carried it, so `filter_tag="anomaly_detection"` discovery queries keep their results. `tests/configs/test_pipeline_preset_metadata.py` pins the vocabulary (cuvis-next mirrors it), one category per preset and the `cuvisnext` set; the pipeline concepts page documents both tags. No dependency floor changes.
+
 ## 0.16.2 - 2026-09-10
 
 - **The cu3s data module opens only the recordings a run uses.** `configs/plugins/cuvis_ai_dataloader.yaml` moves to `v0.6.3`, which takes the assigned recordings as an explicit `files` list (what CuvisNEXT now sends) and, without one, narrows a folder by the sources the split's selectors name. Enumeration previously built a full reader for every `*.cu3s` under `data_dir` before any selector was applied: an SDK session, a processing context and a read of measurement 0 each. `configs/trainrun/dinomaly_custom_cuvisnext.yaml` documents the list next to `data_dir`; the key stays absent so the preset still runs against an older data module.

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_baseline.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_baseline.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - baseline
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_color.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_color.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - cir_false_color
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_color_optimal_threshold.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_color_optimal_threshold.yaml
@@ -9,6 +9,7 @@ metadata:
   - cir_false_color
   - optimal_threshold
   - two_stage
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_rg_color.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_cir_false_rg_color.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - cir_false_rg
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_high_contrast.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_high_contrast.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - high_contrast
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_cir.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_cir.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - supervised_cir
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_full_spectrum.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_full_spectrum.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - supervised_full_spectrum
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_windowed_false_rgb.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/adaclip_supervised_windowed_false_rgb.yaml
@@ -7,6 +7,7 @@ metadata:
   - statistical
   - adaclip
   - supervised_windowed_false_rgb
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/concrete_adaclip_gradient_two_stage.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/concrete_adaclip_gradient_two_stage.yaml
@@ -12,6 +12,7 @@ metadata:
   - adaclip
   - band_selector
   - anomaly_detection
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/adaclip/drcnn_adaclip_gradient.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/adaclip/drcnn_adaclip_gradient.yaml
@@ -9,6 +9,7 @@ metadata:
   - adaclip
   - channel_mixer
   - anomaly_detection
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/deep_svdd/deep_svdd.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/deep_svdd/deep_svdd.yaml
@@ -8,6 +8,7 @@ metadata:
   - statistical
   - deep_svdd
   - anomaly_detection
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/anomaly/rx/channel_selector.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/rx/channel_selector.yaml
@@ -8,6 +8,7 @@ metadata:
   - statistical
   - channel_selector
   - rx
+  - anomaly
   author: cuvis.ai
 plugins:
 - cuvis_ai_builtin

--- a/cuvis_ai/configs/pipeline/anomaly/rx/rx_statistical.yaml
+++ b/cuvis_ai/configs/pipeline/anomaly/rx/rx_statistical.yaml
@@ -5,6 +5,7 @@ metadata:
   tags:
   - statistical
   - rx
+  - anomaly
   author: cuvis.ai
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/medical/blood_perfusion/ndvi.yaml
+++ b/cuvis_ai/configs/pipeline/medical/blood_perfusion/ndvi.yaml
@@ -1,7 +1,8 @@
 metadata:
   name: BloodPerfusion_NDVI_Projection
   description: ''
-  tags: []
+  tags:
+  - medical
   author: ''
   cuvis_ai_version: 0.5.3
 plugins:

--- a/cuvis_ai/configs/pipeline/rtsam2/rtsam2_mask_propagation_view.yaml
+++ b/cuvis_ai/configs/pipeline/rtsam2/rtsam2_mask_propagation_view.yaml
@@ -13,6 +13,7 @@ metadata:
   - rgb
   - video
   - propagation
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - rtsam2

--- a/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_postprocess_view.yaml
+++ b/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_postprocess_view.yaml
@@ -13,6 +13,7 @@ metadata:
   - point-prompt
   - rgb
   - expansion
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - cuvis_ai_builtin

--- a/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_view.yaml
+++ b/cuvis_ai/configs/pipeline/rtsam2/rtsam2_point_expansion_view.yaml
@@ -11,6 +11,7 @@ metadata:
   - point-prompt
   - rgb
   - expansion
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - rtsam2

--- a/cuvis_ai/configs/pipeline/sam3/sam3_mask_propagation_postprocess_view.yaml
+++ b/cuvis_ai/configs/pipeline/sam3/sam3_mask_propagation_postprocess_view.yaml
@@ -13,6 +13,7 @@ metadata:
   - rgb
   - video
   - propagation
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - cuvis_ai_builtin

--- a/cuvis_ai/configs/pipeline/sam3/sam3_mask_propagation_view.yaml
+++ b/cuvis_ai/configs/pipeline/sam3/sam3_mask_propagation_view.yaml
@@ -11,6 +11,7 @@ metadata:
   - rgb
   - video
   - propagation
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - sam3

--- a/cuvis_ai/configs/pipeline/sam3/sam3_point_expansion_postprocess_view.yaml
+++ b/cuvis_ai/configs/pipeline/sam3/sam3_point_expansion_postprocess_view.yaml
@@ -11,6 +11,7 @@ metadata:
   - point-prompt
   - rgb
   - expansion
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - cuvis_ai_builtin

--- a/cuvis_ai/configs/pipeline/sam3/sam3_point_expansion_view.yaml
+++ b/cuvis_ai/configs/pipeline/sam3/sam3_point_expansion_view.yaml
@@ -9,6 +9,7 @@ metadata:
   - point-prompt
   - rgb
   - expansion
+  - cuvisnext
   author: cuvis.ai
 plugins:
 - sam3

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -325,7 +325,7 @@ pipeline.save_to_file(
     metadata=PipelineMetadata(
         name="RX_Anomaly_Detector_v1",
         description="Trained on Lentils dataset",
-        tags=["anomaly-detection", "production"]
+        tags=["anomaly", "production"]
     ),
     validate_nodes=True,
     include_optimizer=False,
@@ -336,6 +336,15 @@ pipeline.save_to_file(
 ```
 
 Generates a YAML config (structure, node hparams, connections) and a `.pt` checkpoint (state_dict with trained weights/statistics, metadata). Training data, intermediate activations, and Python code are **not** saved.
+
+### Tags the shipped presets carry
+
+`metadata.tags` is free-form, but two tags have a fixed meaning for the CuvisNEXT pipeline pickers, and every preset under `cuvis_ai/configs/pipeline/` follows them (`tests/configs/test_pipeline_preset_metadata.py` enforces both):
+
+- **One category word** out of `anomaly`, `segmentation`, `tracking`, `thickness`, `medical`. The picker's category dropdown is derived from the first of these words found in a pipeline's tags (matched case-insensitively, in that order of precedence); a pipeline without one is filed under its folder name below `pipeline/`. cuvis-next mirrors the list as `kPipelineCategories`; extend both together.
+- **`cuvisnext`** marks a preset authored for the app: the pickers list `cuvisnext`-tagged presets and saved training runs by default and hide everything else until "Show all" is on.
+
+Other tags (`sam3`, `rgb`, `video`, `point-prompt`, `statistical`, ...) are descriptive and appear in the picker's tag filter; the category words and `cuvisnext` are not offered there. A training run saved by CuvisNEXT keeps its source preset's tags, so a run trained from an `anomaly` preset is an `anomaly` pipeline too.
 
 ---
 

--- a/tests/configs/test_pipeline_preset_metadata.py
+++ b/tests/configs/test_pipeline_preset_metadata.py
@@ -1,0 +1,84 @@
+"""Tags the CuvisNEXT pipeline pickers read off every shipped preset.
+
+The picker derives a preset's category from the first word of ``PIPELINE_CATEGORIES`` found in
+``metadata.tags`` and lists presets tagged ``cuvisnext`` (plus saved training runs) under its
+default filter. cuvis-next mirrors the vocabulary as ``kPipelineCategories`` in
+``libs/pilot_utility/include/pilot_utility/pipeline_catalog.hpp``; change both together.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from cuvis_ai_schemas.pipeline.config import PipelineConfig
+
+import cuvis_ai
+
+pytestmark = pytest.mark.unit
+
+CONFIGS = Path(cuvis_ai.__file__).resolve().parent / "configs"
+PIPELINES = CONFIGS / "pipeline"
+PRESETS = sorted(PIPELINES.rglob("*.yaml"))
+TRAINRUNS = sorted((CONFIGS / "trainrun").glob("*_cuvisnext.yaml"))
+
+PIPELINE_CATEGORIES = ("anomaly", "segmentation", "tracking", "thickness", "medical")
+CUVISNEXT_PRESETS = {
+    "rtsam2/rtsam2_mask_propagation_view.yaml",
+    "rtsam2/rtsam2_point_expansion_postprocess_view.yaml",
+    "rtsam2/rtsam2_point_expansion_view.yaml",
+    "sam3/sam3_mask_propagation_postprocess_view.yaml",
+    "sam3/sam3_mask_propagation_view.yaml",
+    "sam3/sam3_point_expansion_postprocess_view.yaml",
+    "sam3/sam3_point_expansion_view.yaml",
+    "wafer_thickness/wafer_thickness_pipeline_500nm_cuvisnext_cube.yaml",
+    "wafer_thickness/wafer_thickness_pipeline_cuvisnext_cube.yaml",
+}
+# Kept beside ``anomaly``: core's discovery filters by exact tag, so removing it would empty
+# existing ``filter_tag="anomaly_detection"`` queries.
+LEGACY_ANOMALY_DETECTION = {
+    "anomaly/adaclip/concrete_adaclip_gradient_two_stage.yaml",
+    "anomaly/adaclip/drcnn_adaclip_gradient.yaml",
+    "anomaly/deep_svdd/deep_svdd.yaml",
+}
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(PIPELINES).as_posix()
+
+
+def _tags(path: Path) -> list[str]:
+    return PipelineConfig.load_from_file(path).metadata.tags
+
+
+def test_presets_were_found():
+    assert len(PRESETS) >= 42
+
+
+@pytest.mark.parametrize("preset", PRESETS, ids=_rel)
+def test_preset_carries_exactly_one_category_tag(preset: Path):
+    tags = [tag.lower() for tag in _tags(preset)]
+    found = [category for category in PIPELINE_CATEGORIES if category in tags]
+    assert len(found) == 1, (
+        f"{_rel(preset)}: expected exactly one of {PIPELINE_CATEGORIES} in metadata.tags, found {found}"
+    )
+
+
+def test_cuvisnext_set_is_pinned():
+    tagged = {_rel(preset) for preset in PRESETS if "cuvisnext" in _tags(preset)}
+    assert tagged == CUVISNEXT_PRESETS
+
+
+@pytest.mark.parametrize("trainrun_yaml", TRAINRUNS, ids=lambda p: p.stem)
+def test_cuvisnext_trainrun_source_carries_a_category(trainrun_yaml: Path):
+    """A saved run inherits its source preset's tags, so the source must be categorised."""
+    trainrun = yaml.safe_load(trainrun_yaml.read_text(encoding="utf-8"))
+    pipeline = (trainrun_yaml.parent / trainrun["pipeline"]).resolve()
+    tags = [tag.lower() for tag in _tags(pipeline)]
+    assert any(category in tags for category in PIPELINE_CATEGORIES), _rel(pipeline)
+
+
+@pytest.mark.parametrize("rel", sorted(LEGACY_ANOMALY_DETECTION))
+def test_legacy_anomaly_detection_tag_is_kept(rel: str):
+    assert "anomaly_detection" in _tags(PIPELINES / rel)


### PR DESCRIPTION
## Summary
- Every shipped preset under `configs/pipeline/` carries exactly one category tag in `metadata.tags` (`anomaly`, `segmentation`, `tracking`, `thickness`, `medical`). 28 already did; `anomaly` joins the adaclip, rx and deep_svdd presets beside their existing tags, `medical` the blood-perfusion NDVI preset. Additive only: `anomaly_detection` stays on the three presets that carried it, so `filter_tag="anomaly_detection"` discovery queries keep their results.
- The seven sam3/rtsam2 `*_view` presets are tagged `cuvisnext` beside the two wafer `_cuvisnext_cube` presets: the set the CuvisNEXT pipeline pickers list by default (cuvis-next branch `feature/ALL-6268-picker-filter` derives its category dropdown from the same words).
- `tests/configs/test_pipeline_preset_metadata.py` pins the vocabulary (cuvis-next mirrors it as `kPipelineCategories`), one category per preset, the `cuvisnext` set and the legacy tag; the pipeline concepts page documents both tags. CHANGELOG stamped 0.16.3; no dependency floor changes.

## Test plan
- [x] `uv run pytest tests/configs` in a clean worktree off main (78 passed, 8 skipped)
- [x] `uv run mkdocs build --strict`
- [x] pre-commit and pre-push gates